### PR TITLE
Updating tfwrapper for 0.10.x terraform versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,13 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Because terraform
+*.tfstate.backup
+
+# Some of us like out ctags.
+tags
+
+#And we like vim. :-P
+*.swp
+*.swo

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+Version 0.3.0
+  - Updated to work with the latest 0.10.0 version
+
 Version 0.2.0
 
   - initial release (migrated from previous internal/private gem)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ Build of master branch: [![CircleCI](https://circleci.com/gh/manheim/tfwrapper.s
 
 Documentation: [http://www.rubydoc.info/gems/tfwrapper/](http://www.rubydoc.info/gems/tfwrapper/)
 
-tfwrapper provides Rake tasks for working with [Hashicorp Terraform](https://www.terraform.io/) 0.9+, ensuring proper initialization and passing in variables from the environment or Ruby, as well as optionally pushing some information to Consul. tfwrapper also attempts to detect and retry
-failed runs due to AWS throttling or access denied errors.
+tfwrapper 0.2.x provides Rake tasks for working with [Hashicorp Terraform](https://www.terraform.io/) 0.9.x.
+
+tfwrapper 0.3.x provides Rake tasks for working with [Hashicorp Terraform](https://www.terraform.io/) 0.10.x.
+
+Both ensure proper initialization and passing in variables from the environment or Ruby, as well as optionally 
+pushing some information to Consul. tfwrapper also attempts to detect and retry failed runs due to AWS throttling 
+or access denied errors.
 
 ## Overview
 

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -147,7 +147,7 @@ module TFWrapper
           :"#{nsprefix}:plan"
         ] do |_t, args|
           cmd = cmd_with_targets(
-            ['terraform', 'apply', "-var-file #{var_file_path}"],
+            ['terraform', 'apply', "-auto-approve", "-var-file #{var_file_path}"],
             args[:target],
             args.extras
           )

--- a/lib/tfwrapper/version.rb
+++ b/lib/tfwrapper/version.rb
@@ -4,5 +4,5 @@ module TFWrapper
   # version of the Gem/module; used in the gemspec and in messages.
   # NOTE: When updating this, also update the version in the "Installation"
   # section of README.md
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -5,7 +5,7 @@ require_relative 'acceptance_helpers'
 require 'open3'
 require 'json'
 
-TF_VERSION = '0.9.2'
+TF_VERSION = '0.10.6'
 
 Diplomat.configure do |config|
   config.url = 'http://127.0.0.1:8500'
@@ -84,7 +84,7 @@ describe 'tfwrapper' do
       end
       it 'runs apply correctly and succeeds' do
         expect(@out_err)
-          .to include('terraform_runner command: \'terraform apply -var-file')
+          .to include('terraform_runner command: \'terraform apply -auto-approve -var-file')
         expect(@out_err).to include('consul_keys.testOne: Creating...')
         expect(@out_err).to include(
           'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
@@ -103,7 +103,7 @@ describe 'tfwrapper' do
         state = JSON.parse(Diplomat::Kv.get('terraform/testOne'))
         expect(state['version']).to eq(3)
         expect(state['terraform_version']).to eq(TF_VERSION)
-        expect(state['serial']).to eq(1)
+        expect(state['serial']).to eq(2)
         expect(state['modules'].length).to eq(1)
         expect(state['modules'][0]['outputs']['foo_variable']['value'])
           .to eq('bar')
@@ -183,7 +183,7 @@ describe 'tfwrapper' do
       end
       it 'runs apply correctly and succeeds' do
         expect(@out_err)
-          .to include('terraform_runner command: \'terraform apply -var-file')
+          .to include('terraform_runner command: \'terraform apply -auto-approve -var-file')
         expect(@out_err).to include('consul_keys.testTwo: Creating...')
         expect(@out_err).to include(
           'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
@@ -206,7 +206,7 @@ describe 'tfwrapper' do
         state = JSON.parse(Diplomat::Kv.get('terraform/testTwo/foo'))
         expect(state['version']).to eq(3)
         expect(state['terraform_version']).to eq(TF_VERSION)
-        expect(state['serial']).to eq(1)
+        expect(state['serial']).to eq(2)
         expect(state['modules'].length).to eq(1)
         expect(state['modules'][0]['outputs']['foo_variable']['value'])
           .to eq('fooval')
@@ -242,7 +242,7 @@ describe 'tfwrapper' do
       end
       it 'runs apply correctly and succeeds' do
         expect(@out_err)
-          .to include('terraform_runner command: \'terraform apply -var-file')
+          .to include('terraform_runner command: \'terraform apply -auto-approve -var-file')
         expect(@out_err).to include('consul_keys.testTwo: Creating...')
         expect(@out_err).to include(
           'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
@@ -265,7 +265,7 @@ describe 'tfwrapper' do
         state = JSON.parse(Diplomat::Kv.get('terraform/testTwo/bar'))
         expect(state['version']).to eq(3)
         expect(state['terraform_version']).to eq(TF_VERSION)
-        expect(state['serial']).to eq(1)
+        expect(state['serial']).to eq(2)
         expect(state['modules'].length).to eq(1)
         expect(state['modules'][0]['outputs']['foo_variable']['value'])
           .to eq('fooval')
@@ -372,7 +372,7 @@ describe 'tfwrapper' do
       end
       it 'runs apply correctly and succeeds' do
         expect(@out_err)
-          .to include('terraform_runner command: \'terraform apply -var-file')
+          .to include('terraform_runner command: \'terraform apply -auto-approve -var-file')
         expect(@out_err).to include('consul_keys.testThreeFoo: Creating...')
         expect(@out_err).to include(
           'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
@@ -395,7 +395,7 @@ describe 'tfwrapper' do
         state = JSON.parse(Diplomat::Kv.get('terraform/testThreeFoo'))
         expect(state['version']).to eq(3)
         expect(state['terraform_version']).to eq(TF_VERSION)
-        expect(state['serial']).to eq(1)
+        expect(state['serial']).to eq(2)
         expect(state['modules'].length).to eq(1)
         expect(state['modules'][0]['outputs']['foo_variable']['value'])
           .to eq('fooval')
@@ -429,7 +429,7 @@ describe 'tfwrapper' do
       end
       it 'runs apply correctly and succeeds' do
         expect(@out_err)
-          .to include('terraform_runner command: \'terraform apply -var-file')
+          .to include('terraform_runner command: \'terraform apply -auto-approve -var-file')
         expect(@out_err).to include('consul_keys.testThreeBar: Creating...')
         expect(@out_err).to include(
           'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
@@ -452,7 +452,7 @@ describe 'tfwrapper' do
         state = JSON.parse(Diplomat::Kv.get('terraform/testThreeBar'))
         expect(state['version']).to eq(3)
         expect(state['terraform_version']).to eq(TF_VERSION)
-        expect(state['serial']).to eq(1)
+        expect(state['serial']).to eq(2)
         expect(state['modules'].length).to eq(1)
         expect(state['modules'][0]['outputs']['foo_variable']['value'])
           .to eq('fooval')
@@ -486,7 +486,7 @@ describe 'tfwrapper' do
       end
       it 'runs apply correctly and succeeds' do
         expect(@out_err)
-          .to include('terraform_runner command: \'terraform apply -var-file')
+          .to include('terraform_runner command: \'terraform apply -auto-approve -var-file')
         expect(@out_err).to include('consul_keys.testThreeBaz: Creating...')
         expect(@out_err).to include(
           'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
@@ -508,7 +508,7 @@ describe 'tfwrapper' do
         state = JSON.parse(Diplomat::Kv.get('terraform/testThreeBaz'))
         expect(state['version']).to eq(3)
         expect(state['terraform_version']).to eq(TF_VERSION)
-        expect(state['serial']).to eq(1)
+        expect(state['serial']).to eq(2)
         expect(state['modules'].length).to eq(1)
         expect(state['modules'][0]['outputs']['foo_variable']['value'])
           .to eq('fooval')

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -354,7 +354,7 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:terraform_runner)
       allow(subject).to receive(:update_consul_stack_env_vars)
       expect(subject).to receive(:terraform_runner).once
-        .with('terraform apply -var-file file.tfvars.json')
+        .with('terraform apply -auto-approve -var-file file.tfvars.json')
       expect(subject).to_not receive(:update_consul_stack_env_vars)
       Rake.application['tf:apply'].invoke
     end
@@ -363,7 +363,7 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
       expect(subject).to receive(:terraform_runner).once
-        .with('terraform apply -var-file file.tfvars.json ' \
+        .with('terraform apply -auto-approve -var-file file.tfvars.json ' \
               '-target tar.get[1]')
       Rake.application['tf:apply'].invoke('tar.get[1]')
     end
@@ -372,7 +372,7 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
       expect(subject).to receive(:terraform_runner).once
-        .with('terraform apply -var-file file.tfvars.json ' \
+        .with('terraform apply -auto-approve -var-file file.tfvars.json ' \
               '-target tar.get[1] -target t.gt[2] -target my.target[3]')
       Rake.application['tf:apply'].invoke(
         'tar.get[1]', 't.gt[2]', 'my.target[3]'
@@ -385,7 +385,7 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:terraform_runner)
       allow(subject).to receive(:update_consul_stack_env_vars)
       expect(subject).to receive(:terraform_runner).once
-        .with('terraform apply -var-file file.tfvars.json')
+        .with('terraform apply -auto-approve -var-file file.tfvars.json')
       expect(subject).to receive(:update_consul_stack_env_vars).once
       Rake.application['tf:apply'].invoke
     end


### PR DESCRIPTION
Working on updating tfwrapper to work with 0.10.0.  Primary issues I've seen are:

- [x]  Some changes in tfstate.  While I feel a bit odd validating the tfstate as much as we do (it's an internal format to Terraform), I have no problem fixing what's there.  See my comment for how this issue played out.
- [x] We need to add the -auto-approve flag to all apply commands.  While this flag defaults to `true` in 0.10 (making it's inclusion in the command redundant) it is planned to eventually default to `false`.  When `false`, this causes terraform to block and request you interactively approve changes.  tfwrapper is for automating terraform and there's no one sitting at a console to press 'Y'. #3 
