### PR TITLE
Add support for running Procs before and after body of each task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,8 @@ Style/MutableConstant:
 Style/MultilineMethodCallIndentation:
   Exclude:
     - 'spec/unit/raketasks_spec.rb'
+
+# Offense count: 28
+# Cop supports --auto-correct.
+Style/Proc:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,20 @@
 Metrics/AbcSize:
-  Max: 22
+  Max: 40
 
 Metrics/BlockLength:
-  Max: 1000
+  Max: 1300
 
 Metrics/ClassLength:
   Max: 500
 
 Metrics/MethodLength:
   Max: 100
+
+Metrics/PerceivedComplexity:
+  Max: 8
+
+Metrics/CyclomaticComplexity:
+  Max: 8
 
 # These are to compensate for some warnings that differ by
 # rubocop/ruby version
@@ -21,6 +27,6 @@ Style/MutableConstant:
     - 'lib/tfwrapper/version.rb'
     - 'spec/acceptance/acceptance_spec.rb'
 
-Layout/MultilineMethodCallIndentation:
+Style/MultilineMethodCallIndentation:
   Exclude:
     - 'spec/unit/raketasks_spec.rb'

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+Version 0.4.0
+
+  - Add support for calling Procs at the beginning and end of each task.
+  - Documentation cleanup.
+
 Version 0.3.0
 
   - Add `tf:output` and `tf:output_json` Rake tasks

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This Gem provides the following Rake tasks:
   ``bundle exec rake tf:destroy[aws_instance.foo[1],aws_instance.bar[2]]``; see the
   [destroy documentation](https://www.terraform.io/docs/commands/destroy.html) for more information.
 * __tf:write_tf_vars__ - used as a prerequisite for other tasks; write Terraform variables to file on disk
+* __tf:output__ - run ``terraform output``
+* __tf:output_json__ - run ``terraform output -json``
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,33 @@ TFWrapper::RakeTasks.install_tasks(
 )
 ```
 
+### Calling Procs At Beginning and End of Tasks
+
+Version 0.4.0 of tfwrapper introduced the ability to call arbitrary Ruby Procs from within the Rake tasks,
+at the beginning and end of the task (i.e. before and after the terraform-handling code within the task).
+This is accomplished via the ``:before_proc`` and ``:after_proc`` options, each taking a Proc instance.
+
+The Procs take two positional arguments; a ``String`` containing the full, namespaced name of the Rake task
+it was called from, and the ``String`` ``tf_dir`` argument passed to the TFWrapper::RakeTasks class (exactly as specified).
+
+This could be used for things such as showing the output of state after a terraform run,
+triggering a [tfenv](https://github.com/kamatama41/tfenv) installation, etc.
+
+```ruby
+require 'tfwrapper/raketasks'
+
+TFWrapper::RakeTasks.install_tasks(
+  '.',
+  before_proc: Proc.new do |taskname, tfdir|
+    next unless taskname == 'tf:apply' # example of only executing for apply task in default namespace
+    puts "Executing #{taskname} task with tfdir=#{tfdir}"
+  end,
+  after_proc: Proc.new do |taskname, tfdir|
+    puts "Executed #{taskname} task with tfdir=#{tfdir}"
+  end
+)
+```
+
 ### Environment Variables to Consul
 
 tfwrapper also includes functionality to push environment variables to Consul

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -8,10 +8,6 @@ require 'tfwrapper/version'
 
 module TFWrapper
   # Generates Rake tasks for working with Terraform.
-  #
-  # Before using this, the ``CONSUL_HOST`` environment variable must be set.
-  #
-  # __NOTE:__ Be sure to document all tasks in README.md
   class RakeTasks
     include Rake::DSL if defined? Rake::DSL
 

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -7,7 +7,7 @@ require 'rubygems'
 require 'tfwrapper/version'
 
 module TFWrapper
-  # Generates Rake tasks for working with Terraform at Manheim.
+  # Generates Rake tasks for working with Terraform.
   #
   # Before using this, the ``CONSUL_HOST`` environment variable must be set.
   #
@@ -34,7 +34,7 @@ module TFWrapper
 
     attr_reader :tf_version
 
-    # Generate Rake tasks for working with Terraform at Manheim.
+    # Generate Rake tasks for working with Terraform.
     #
     # @param tf_dir [String] Terraform config directory, relative to Rakefile.
     #   Set to '.' if the Rakefile is in the same directory as the ``.tf``

--- a/lib/tfwrapper/version.rb
+++ b/lib/tfwrapper/version.rb
@@ -4,5 +4,5 @@ module TFWrapper
   # version of the Gem/module; used in the gemspec and in messages.
   # NOTE: When updating this, also update the version in the "Installation"
   # section of README.md
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/acceptance/acceptance_helpers.rb
+++ b/spec/acceptance/acceptance_helpers.rb
@@ -4,10 +4,13 @@ require 'ffi'
 require 'faraday'
 require 'json'
 
-def cleanup_tf
-  fixture_dir = File.absolute_path(
+def fixture_dir
+  File.absolute_path(
     File.join(File.dirname(__FILE__), '..', 'fixtures')
   )
+end
+
+def cleanup_tf
   Dir.glob("#{fixture_dir}/**/.terraform").each do |d|
     FileUtils.rmtree(d) if File.directory?(d)
   end

--- a/spec/acceptance/acceptance_helpers.rb
+++ b/spec/acceptance/acceptance_helpers.rb
@@ -73,7 +73,6 @@ class HashicorpFetcher
     true
   end
 
-  # rubocop:disable Metrics/AbcSize
   def fetch
     return File.realpath(bin_path) unless vendored_required?
     require 'open-uri'
@@ -102,7 +101,6 @@ class HashicorpFetcher
     raise StandardErrro, 'Error: wrong version' unless is_correct_version?
     File.realpath(bin_path)
   end
-  # rubocop:enable Metrics/AbcSize
 
   def is_correct_version?
     ver = `#{bin_path} version`.strip

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -239,12 +239,22 @@ describe 'tfwrapper' do
       end
       it 'calls the before proc with the proper arguments before terraform' do
         expect(@out_err).to match(
-          /Executing tf:apply task with tfdir=foo\/bar.*terraform_runner command: 'terraform apply.*/
+          Regexp.new(
+            '.*Executing tf:apply task with tfdir=' \
+            "#{Regexp.escape(fixture_dir)}\/testTwo\/foo\/bar.*" \
+            'terraform_runner command: \'terraform apply.*',
+            Regexp::MULTILINE
+          )
         )
       end
       it 'calls the after proc with the proper arguments after terraform' do
         expect(@out_err).to match(
-          /terraform_runner command: 'terraform apply.*Executed tf:apply task with tfdir=foo\/bar/
+          Regexp.new(
+            '.*terraform_runner command: \'terraform apply.*Executed ' \
+            "tf:apply task with tfdir=#{Regexp.escape(fixture_dir)}" \
+            '\/testTwo\/foo\/bar.*',
+            Regexp::MULTILINE
+          )
         )
       end
       it 'writes the vars file' do
@@ -351,14 +361,17 @@ describe 'tfwrapper' do
         expect(@out_err).to include('foo_variable = fooval')
         expect(@out_err).to include('bar_variable = barval')
       end
-      it 'calls the before proc with the proper arguments before terraform' do
+      it 'calls the procs with the proper arguments in proper order' do
         expect(@out_err).to match(
-          /Executing tf:output task with tfdir=foo\/bar.*terraform_runner command: terraform output.*/
-        )
-      end
-      it 'calls the after proc with the proper arguments after terraform' do
-        expect(@out_err).to match(
-          /terraform_runner command: terraform output.*Executed tf:output task with tfdir=foo\/bar/
+          Regexp.new(
+            '.*Executing tf:output task with tfdir=' \
+            "#{Regexp.escape(fixture_dir)}\/testTwo\/foo\/bar\n" \
+            'bar_variable = barval' + "\n" \
+            'foo_variable = fooval' + "\n" \
+            'Executed tf:output task with tfdir=' \
+            "#{Regexp.escape(fixture_dir)}\/testTwo\/foo\/bar\n",
+            Regexp::MULTILINE
+          )
         )
       end
     end
@@ -493,12 +506,22 @@ describe 'tfwrapper' do
       end
       it 'calls the before proc with the proper arguments before terraform' do
         expect(@out_err).to match(
-          /Executing tf:apply task with tfdir=foo.*terraform_runner command:.*/
+          Regexp.new(
+            '.*Executing tf:apply task with tfdir=' \
+            "#{Regexp.escape(fixture_dir)}\/testThree\/foo.*" \
+            'terraform_runner command: \'terraform apply.*',
+            Regexp::MULTILINE
+          )
         )
       end
       it 'calls the after proc with the proper arguments after terraform' do
         expect(@out_err).to match(
-          /terraform_runner command:.*Executed tf:apply task with tfdir=foo/
+          Regexp.new(
+            '.*terraform_runner command: \'terraform apply.*Executed ' \
+            "tf:apply task with tfdir=#{Regexp.escape(fixture_dir)}" \
+            '\/testThree\/foo.*',
+            Regexp::MULTILINE
+          )
         )
       end
     end
@@ -583,12 +606,22 @@ describe 'tfwrapper' do
       end
       it 'calls the before proc with the proper arguments before terraform' do
         expect(@out_err).to match(
-          /Executing bar_tf:output task with tfdir=bar.*terraform_runner command: 'terraform apply.*/
+          Regexp.new(
+            '.*Executing bar_tf:apply task with tfdir=' \
+            "#{Regexp.escape(fixture_dir)}\/testThree\/bar.*" \
+            'terraform_runner command: \'terraform apply.*',
+            Regexp::MULTILINE
+          )
         )
       end
       it 'calls the after proc with the proper arguments after terraform' do
         expect(@out_err).to match(
-          /terraform_runner command: 'terraform apply.*Executed bar_tf:output task with tfdir=bar/
+          Regexp.new(
+            '.*terraform_runner command: \'terraform apply.*Executed ' \
+            "bar_tf:apply task with tfdir=#{Regexp.escape(fixture_dir)}" \
+            '\/testThree\/bar.*',
+            Regexp::MULTILINE
+          )
         )
       end
     end

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -237,6 +237,16 @@ describe 'tfwrapper' do
           "Outputs:\n\nbar_variable = barval\nfoo_variable = fooval"
         )
       end
+      it 'calls the before proc with the proper arguments before terraform' do
+        expect(@out_err).to match(
+          /Executing tf:apply task with tfdir=foo\/bar.*terraform_runner command: 'terraform apply.*/
+        )
+      end
+      it 'calls the after proc with the proper arguments after terraform' do
+        expect(@out_err).to match(
+          /terraform_runner command: 'terraform apply.*Executed tf:apply task with tfdir=foo\/bar/
+        )
+      end
       it 'writes the vars file' do
         expect(File.file?(@varpath)).to be(true)
         c = File.open(@varpath, 'r').read
@@ -340,6 +350,16 @@ describe 'tfwrapper' do
       it 'shows the outputs' do
         expect(@out_err).to include('foo_variable = fooval')
         expect(@out_err).to include('bar_variable = barval')
+      end
+      it 'calls the before proc with the proper arguments before terraform' do
+        expect(@out_err).to match(
+          /Executing tf:output task with tfdir=foo\/bar.*terraform_runner command: terraform output.*/
+        )
+      end
+      it 'calls the after proc with the proper arguments after terraform' do
+        expect(@out_err).to match(
+          /terraform_runner command: terraform output.*Executed tf:output task with tfdir=foo\/bar/
+        )
       end
     end
   end
@@ -471,6 +491,16 @@ describe 'tfwrapper' do
           .to include('consul_keys.testThreeFoo')
         expect(state['modules'][0]['resources'].length).to eq(1)
       end
+      it 'calls the before proc with the proper arguments before terraform' do
+        expect(@out_err).to match(
+          /Executing tf:apply task with tfdir=foo.*terraform_runner command:.*/
+        )
+      end
+      it 'calls the after proc with the proper arguments after terraform' do
+        expect(@out_err).to match(
+          /terraform_runner command:.*Executed tf:apply task with tfdir=foo/
+        )
+      end
     end
     describe 'tf:output' do
       before(:all) do
@@ -550,6 +580,16 @@ describe 'tfwrapper' do
         expect(state['modules'][0]['resources'])
           .to include('consul_keys.testThreeBar')
         expect(state['modules'][0]['resources'].length).to eq(1)
+      end
+      it 'calls the before proc with the proper arguments before terraform' do
+        expect(@out_err).to match(
+          /Executing bar_tf:output task with tfdir=bar.*terraform_runner command: 'terraform apply.*/
+        )
+      end
+      it 'calls the after proc with the proper arguments after terraform' do
+        expect(@out_err).to match(
+          /terraform_runner command: 'terraform apply.*Executed bar_tf:output task with tfdir=bar/
+        )
       end
     end
     describe 'bar_tf:output' do

--- a/spec/fixtures/testThree/Rakefile
+++ b/spec/fixtures/testThree/Rakefile
@@ -2,12 +2,9 @@
 
 require 'tfwrapper/raketasks'
 
-# @option opts [String] :consul_url URL to access Consul at, for the
-#   ``:consul_env_vars_prefix`` option.
-# @option opts [String] :consul_env_vars_prefix if specified and not nil,
-#   write the environment variables used from ``tf_vars_from_env``
-#   and their values to JSON at this path in Consul. This should have
-#   the same naming constraints as ``consul_prefix``.
+# we want to get real streaming output
+STDOUT.sync = true
+STDERR.sync = true
 
 TFWrapper::RakeTasks.install_tasks(
   'foo',

--- a/spec/fixtures/testThree/Rakefile
+++ b/spec/fixtures/testThree/Rakefile
@@ -13,14 +13,26 @@ TFWrapper::RakeTasks.install_tasks(
   'foo',
   backend_config: { 'path' => 'terraform/testThreeFoo' },
   tf_vars_from_env: { 'foo' => 'FOO' },
-  tf_extra_vars: { 'bar' => 'barONEval' }
+  tf_extra_vars: { 'bar' => 'barONEval' },
+  before_proc: Proc.new do |taskname, tfdir|
+    puts "Executing #{taskname} task with tfdir=#{tfdir}"
+  end,
+  after_proc: Proc.new do |taskname, tfdir|
+    puts "Executed #{taskname} task with tfdir=#{tfdir}"
+  end
 )
 
 TFWrapper::RakeTasks.install_tasks(
   'bar',
   namespace_prefix: 'bar',
   tf_vars_from_env: { 'foo' => 'FOO' },
-  tf_extra_vars: { 'bar' => 'barTWOval' }
+  tf_extra_vars: { 'bar' => 'barTWOval' },
+  before_proc: Proc.new do |taskname, tfdir|
+    puts "Executing #{taskname} task with tfdir=#{tfdir}"
+  end,
+  after_proc: Proc.new do |taskname, tfdir|
+    puts "Executed #{taskname} task with tfdir=#{tfdir}"
+  end
 )
 
 TFWrapper::RakeTasks.install_tasks(
@@ -28,5 +40,11 @@ TFWrapper::RakeTasks.install_tasks(
   namespace_prefix: 'baz',
   tf_vars_from_env: { 'foo' => 'FOO' },
   consul_url: 'http://127.0.0.1:8500',
-  consul_env_vars_prefix: 'vars/testThreeBaz'
+  consul_env_vars_prefix: 'vars/testThreeBaz',
+  before_proc: Proc.new do |taskname, tfdir|
+    puts "Executing #{taskname} task with tfdir=#{tfdir}"
+  end,
+  after_proc: Proc.new do |taskname, tfdir|
+    puts "Executed #{taskname} task with tfdir=#{tfdir}"
+  end
 )

--- a/spec/fixtures/testThree/Rakefile
+++ b/spec/fixtures/testThree/Rakefile
@@ -14,10 +14,10 @@ TFWrapper::RakeTasks.install_tasks(
   backend_config: { 'path' => 'terraform/testThreeFoo' },
   tf_vars_from_env: { 'foo' => 'FOO' },
   tf_extra_vars: { 'bar' => 'barONEval' },
-  before_proc: Proc do |taskname, tfdir|
+  before_proc: Proc.new do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc do |taskname, tfdir|
+  after_proc: Proc.new do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )
@@ -27,10 +27,10 @@ TFWrapper::RakeTasks.install_tasks(
   namespace_prefix: 'bar',
   tf_vars_from_env: { 'foo' => 'FOO' },
   tf_extra_vars: { 'bar' => 'barTWOval' },
-  before_proc: Proc do |taskname, tfdir|
+  before_proc: Proc.new do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc do |taskname, tfdir|
+  after_proc: Proc.new do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )
@@ -41,10 +41,10 @@ TFWrapper::RakeTasks.install_tasks(
   tf_vars_from_env: { 'foo' => 'FOO' },
   consul_url: 'http://127.0.0.1:8500',
   consul_env_vars_prefix: 'vars/testThreeBaz',
-  before_proc: Proc do |taskname, tfdir|
+  before_proc: Proc.new do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc do |taskname, tfdir|
+  after_proc: Proc.new do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )

--- a/spec/fixtures/testThree/Rakefile
+++ b/spec/fixtures/testThree/Rakefile
@@ -14,10 +14,10 @@ TFWrapper::RakeTasks.install_tasks(
   backend_config: { 'path' => 'terraform/testThreeFoo' },
   tf_vars_from_env: { 'foo' => 'FOO' },
   tf_extra_vars: { 'bar' => 'barONEval' },
-  before_proc: Proc.new do |taskname, tfdir|
+  before_proc: Proc do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc.new do |taskname, tfdir|
+  after_proc: Proc do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )
@@ -27,10 +27,10 @@ TFWrapper::RakeTasks.install_tasks(
   namespace_prefix: 'bar',
   tf_vars_from_env: { 'foo' => 'FOO' },
   tf_extra_vars: { 'bar' => 'barTWOval' },
-  before_proc: Proc.new do |taskname, tfdir|
+  before_proc: Proc do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc.new do |taskname, tfdir|
+  after_proc: Proc do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )
@@ -41,10 +41,10 @@ TFWrapper::RakeTasks.install_tasks(
   tf_vars_from_env: { 'foo' => 'FOO' },
   consul_url: 'http://127.0.0.1:8500',
   consul_env_vars_prefix: 'vars/testThreeBaz',
-  before_proc: Proc.new do |taskname, tfdir|
+  before_proc: Proc do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc.new do |taskname, tfdir|
+  after_proc: Proc do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )

--- a/spec/fixtures/testTwo/Rakefile
+++ b/spec/fixtures/testTwo/Rakefile
@@ -9,10 +9,10 @@ TFWrapper::RakeTasks.install_tasks(
   },
   tf_vars_from_env: { 'foo' => 'FOO' },
   tf_extra_vars: { 'bar' => 'barval' },
-  before_proc: Proc do |taskname, tfdir|
+  before_proc: Proc.new do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc do |taskname, tfdir|
+  after_proc: Proc.new do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )

--- a/spec/fixtures/testTwo/Rakefile
+++ b/spec/fixtures/testTwo/Rakefile
@@ -9,10 +9,10 @@ TFWrapper::RakeTasks.install_tasks(
   },
   tf_vars_from_env: { 'foo' => 'FOO' },
   tf_extra_vars: { 'bar' => 'barval' },
-  before_proc: Proc.new do |taskname, tfdir|
+  before_proc: Proc do |taskname, tfdir|
     puts "Executing #{taskname} task with tfdir=#{tfdir}"
   end,
-  after_proc: Proc.new do |taskname, tfdir|
+  after_proc: Proc do |taskname, tfdir|
     puts "Executed #{taskname} task with tfdir=#{tfdir}"
   end
 )

--- a/spec/fixtures/testTwo/Rakefile
+++ b/spec/fixtures/testTwo/Rakefile
@@ -8,5 +8,11 @@ TFWrapper::RakeTasks.install_tasks(
     'path' => "terraform/testTwo/#{ENV['TFSUFFIX']}"
   },
   tf_vars_from_env: { 'foo' => 'FOO' },
-  tf_extra_vars: { 'bar' => 'barval' }
+  tf_extra_vars: { 'bar' => 'barval' },
+  before_proc: Proc.new do |taskname, tfdir|
+    puts "Executing #{taskname} task with tfdir=#{tfdir}"
+  end,
+  after_proc: Proc.new do |taskname, tfdir|
+    puts "Executed #{taskname} task with tfdir=#{tfdir}"
+  end
 )

--- a/spec/fixtures/testTwo/Rakefile
+++ b/spec/fixtures/testTwo/Rakefile
@@ -2,6 +2,10 @@
 
 require 'tfwrapper/raketasks'
 
+# we want to get real streaming output
+STDOUT.sync = true
+STDERR.sync = true
+
 TFWrapper::RakeTasks.install_tasks(
   'foo/bar',
   backend_config: {

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -12,7 +12,8 @@ require 'rubygems'
 describe TFWrapper::RakeTasks do
   subject do
     allow(Rake.application).to receive(:rakefile).and_return('Rakefile')
-    allow(Rake.application).to receive(:original_dir).and_return('/path/to/rakedir')
+    allow(Rake.application).to receive(:original_dir)
+      .and_return('/path/to/rakedir')
     allow(File).to receive(:realpath) { |p| p }
     subj = TFWrapper::RakeTasks.new('tfdir')
     subj.instance_variable_set('@tf_dir', 'tfdir')
@@ -72,14 +73,14 @@ describe TFWrapper::RakeTasks do
       allow(Rake.application).to receive(:rakefile)
         .and_return('/path/to')
       allow(File).to receive(:realpath) { |p| p.sub('../', '') }
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to_not receive(:foo)
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to_not receive(:foo)
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       cls = TFWrapper::RakeTasks.new(
         'tf/dir',
         consul_env_vars_prefix: 'cvprefix',
@@ -112,22 +113,24 @@ describe TFWrapper::RakeTasks do
           .and_return('/rake/dir/Rakefile')
         allow(File).to receive(:realpath) { |p| p.sub('../', '') }
         allow(File).to receive(:file?).and_return(true)
-        expect { TFWrapper::RakeTasks.new('tfdir', before_proc: "foo") }.to
-          raise_error(TypeError, /before_proc must be a Proc instance, not a String/)
+        expect { TFWrapper::RakeTasks.new('tfdir', before_proc: 'foo') }
+          .to raise_error(
+            TypeError,
+            /before_proc must be a Proc instance, not a String/
+          )
       end
     end
     context 'when after_proc is not a proc or nil' do
       it 'raises an error' do
-        allow(ENV).to receive(:[])
-        allow(ENV).to receive(:[]).with('CONSUL_HOST').and_return('chost')
-        allow(ENV).to receive(:[]).with('ENVIRONMENT').and_return('myenv')
-        allow(ENV).to receive(:[]).with('PROJECT').and_return('myproj')
-        allow(Rake.application).to receive(:rakefile)
-          .and_return('/rake/dir/Rakefile')
-        allow(File).to receive(:realpath) { |p| p.sub('../', '') }
-        allow(File).to receive(:file?).and_return(true)
-        expect { TFWrapper::RakeTasks.new('tfdir', after_proc: "foo") }.to
-          raise_error(TypeError, /after_proc must be a Proc instance, not a String/)
+        allow(Rake.application).to receive(:original_dir)
+          .and_return('/rake/dir')
+        allow(Rake.application).to receive(:rakefile).and_return('Rakefile')
+        allow(File).to receive(:realpath) { |p| p }
+        expect { TFWrapper::RakeTasks.new('tfdir', after_proc: 'foo') }
+          .to raise_error(
+            TypeError,
+            /after_proc must be a Proc instance, not a String/
+          )
       end
     end
     context 'when consul_url is nil but consul_env_vars_prefix is not' do
@@ -336,10 +339,10 @@ describe TFWrapper::RakeTasks do
     it 'calls before_proc if not nil' do
       Rake.application['tf:init'].clear_prerequisites
 
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:init', 'tfdir')
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       allow(TFWrapper::Helpers).to receive(:check_env_vars)
@@ -353,10 +356,10 @@ describe TFWrapper::RakeTasks do
     it 'calls after_proc if not nil' do
       Rake.application['tf:init'].clear_prerequisites
 
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:init', 'tfdir')
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       allow(TFWrapper::Helpers).to receive(:check_env_vars)
@@ -421,10 +424,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:plan', 'tfdir')
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:plan'].invoke
@@ -434,10 +437,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:plan', 'tfdir')
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:plan'].invoke
@@ -468,10 +471,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:terraform_runner)
       allow(subject).to receive(:update_consul_stack_env_vars)
 
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:apply', 'tfdir')
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:apply'].invoke
@@ -482,10 +485,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:terraform_runner)
       allow(subject).to receive(:update_consul_stack_env_vars)
 
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:apply', 'tfdir')
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:apply'].invoke
@@ -617,10 +620,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:refresh', 'tfdir')
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:refresh'].invoke
@@ -630,10 +633,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:refresh', 'tfdir')
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:refresh'].invoke
@@ -692,10 +695,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:destroy', 'tfdir')
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:destroy'].invoke
@@ -705,10 +708,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:destroy', 'tfdir')
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:destroy'].invoke
@@ -770,10 +773,11 @@ describe TFWrapper::RakeTasks do
         allow(File).to receive(:open).and_yield(f_dbl)
         allow(f_dbl).to receive(:write)
 
-        before_dbl = double()
+        before_dbl = double
         allow(before_dbl).to receive(:foo)
-        expect(before_dbl).to receive(:foo).once.with('tf:write_tf_vars', 'tfdir')
-        bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+        expect(before_dbl).to receive(:foo).once
+          .with('tf:write_tf_vars', 'tfdir')
+        bproc = Proc { |a, b| before_dbl.foo(a, b) }
         subject.instance_variable_set('@before_proc', bproc)
 
         Rake.application['tf:write_tf_vars'].invoke
@@ -790,10 +794,11 @@ describe TFWrapper::RakeTasks do
         allow(File).to receive(:open).and_yield(f_dbl)
         allow(f_dbl).to receive(:write)
 
-        after_dbl = double()
+        after_dbl = double
         allow(after_dbl).to receive(:foo)
-        expect(after_dbl).to receive(:foo).once.with('tf:write_tf_vars', 'tfdir')
-        aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+        expect(after_dbl).to receive(:foo).once
+          .with('tf:write_tf_vars', 'tfdir')
+        aproc = Proc { |a, b| after_dbl.foo(a, b) }
         subject.instance_variable_set('@after_proc', aproc)
 
         Rake.application['tf:write_tf_vars'].invoke
@@ -856,10 +861,11 @@ describe TFWrapper::RakeTasks do
         allow(File).to receive(:open).and_yield(f_dbl)
         allow(f_dbl).to receive(:write)
 
-        before_dbl = double()
+        before_dbl = double
         allow(before_dbl).to receive(:foo)
-        expect(before_dbl).to receive(:foo).once.with('foo_tf:write_tf_vars', 'tfdir')
-        bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+        expect(before_dbl).to receive(:foo).once
+          .with('foo_tf:write_tf_vars', 'tfdir')
+        bproc = Proc { |a, b| before_dbl.foo(a, b) }
         subject.instance_variable_set('@before_proc', bproc)
 
         Rake.application['foo_tf:write_tf_vars'].invoke
@@ -877,10 +883,11 @@ describe TFWrapper::RakeTasks do
         allow(File).to receive(:open).and_yield(f_dbl)
         allow(f_dbl).to receive(:write)
 
-        after_dbl = double()
+        after_dbl = double
         allow(after_dbl).to receive(:foo)
-        expect(after_dbl).to receive(:foo).once.with('foo_tf:write_tf_vars', 'tfdir')
-        aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+        expect(after_dbl).to receive(:foo).once
+          .with('foo_tf:write_tf_vars', 'tfdir')
+        aproc = Proc { |a, b| after_dbl.foo(a, b) }
         subject.instance_variable_set('@after_proc', aproc)
 
         Rake.application['foo_tf:write_tf_vars'].invoke
@@ -919,10 +926,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:output', 'tfdir')
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:output'].invoke
@@ -932,10 +939,10 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:output', 'tfdir')
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:output'].invoke
@@ -954,27 +961,27 @@ describe TFWrapper::RakeTasks do
       Rake.application['tf:output_json'].invoke
     end
     it 'output_json calls before_proc if not nil' do
-      Rake.application['tf:output'].clear_prerequisites
+      Rake.application['tf:output_json'].clear_prerequisites
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      before_dbl = double()
+      before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:output_json', 'tfdir')
-      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:output_json'].invoke
     end
     it 'output_json calls after_proc if not nil' do
-      Rake.application['tf:output'].clear_prerequisites
+      Rake.application['tf:output_json'].clear_prerequisites
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
 
-      after_dbl = double()
+      after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:output_json', 'tfdir')
-      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:output_json'].invoke

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -79,8 +79,8 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to_not receive(:foo)
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       cls = TFWrapper::RakeTasks.new(
         'tf/dir',
         consul_env_vars_prefix: 'cvprefix',
@@ -342,7 +342,7 @@ describe TFWrapper::RakeTasks do
       before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:init', 'tfdir')
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       allow(TFWrapper::Helpers).to receive(:check_env_vars)
@@ -359,7 +359,7 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:init', 'tfdir')
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       allow(TFWrapper::Helpers).to receive(:check_env_vars)
@@ -427,7 +427,7 @@ describe TFWrapper::RakeTasks do
       before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:plan', 'tfdir')
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:plan'].invoke
@@ -440,7 +440,7 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:plan', 'tfdir')
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:plan'].invoke
@@ -474,7 +474,7 @@ describe TFWrapper::RakeTasks do
       before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:apply', 'tfdir')
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:apply'].invoke
@@ -488,7 +488,7 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:apply', 'tfdir')
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:apply'].invoke
@@ -623,7 +623,7 @@ describe TFWrapper::RakeTasks do
       before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:refresh', 'tfdir')
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:refresh'].invoke
@@ -636,7 +636,7 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:refresh', 'tfdir')
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:refresh'].invoke
@@ -698,7 +698,7 @@ describe TFWrapper::RakeTasks do
       before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:destroy', 'tfdir')
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:destroy'].invoke
@@ -711,7 +711,7 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:destroy', 'tfdir')
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:destroy'].invoke
@@ -777,7 +777,7 @@ describe TFWrapper::RakeTasks do
         allow(before_dbl).to receive(:foo)
         expect(before_dbl).to receive(:foo).once
           .with('tf:write_tf_vars', 'tfdir')
-        bproc = Proc { |a, b| before_dbl.foo(a, b) }
+        bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
         subject.instance_variable_set('@before_proc', bproc)
 
         Rake.application['tf:write_tf_vars'].invoke
@@ -798,7 +798,7 @@ describe TFWrapper::RakeTasks do
         allow(after_dbl).to receive(:foo)
         expect(after_dbl).to receive(:foo).once
           .with('tf:write_tf_vars', 'tfdir')
-        aproc = Proc { |a, b| after_dbl.foo(a, b) }
+        aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
         subject.instance_variable_set('@after_proc', aproc)
 
         Rake.application['tf:write_tf_vars'].invoke
@@ -865,7 +865,7 @@ describe TFWrapper::RakeTasks do
         allow(before_dbl).to receive(:foo)
         expect(before_dbl).to receive(:foo).once
           .with('foo_tf:write_tf_vars', 'tfdir')
-        bproc = Proc { |a, b| before_dbl.foo(a, b) }
+        bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
         subject.instance_variable_set('@before_proc', bproc)
 
         Rake.application['foo_tf:write_tf_vars'].invoke
@@ -887,7 +887,7 @@ describe TFWrapper::RakeTasks do
         allow(after_dbl).to receive(:foo)
         expect(after_dbl).to receive(:foo).once
           .with('foo_tf:write_tf_vars', 'tfdir')
-        aproc = Proc { |a, b| after_dbl.foo(a, b) }
+        aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
         subject.instance_variable_set('@after_proc', aproc)
 
         Rake.application['foo_tf:write_tf_vars'].invoke
@@ -929,7 +929,7 @@ describe TFWrapper::RakeTasks do
       before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:output', 'tfdir')
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:output'].invoke
@@ -942,7 +942,7 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:output', 'tfdir')
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:output'].invoke
@@ -968,7 +968,7 @@ describe TFWrapper::RakeTasks do
       before_dbl = double
       allow(before_dbl).to receive(:foo)
       expect(before_dbl).to receive(:foo).once.with('tf:output_json', 'tfdir')
-      bproc = Proc { |a, b| before_dbl.foo(a, b) }
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
       subject.instance_variable_set('@before_proc', bproc)
 
       Rake.application['tf:output_json'].invoke
@@ -981,7 +981,7 @@ describe TFWrapper::RakeTasks do
       after_dbl = double
       allow(after_dbl).to receive(:foo)
       expect(after_dbl).to receive(:foo).once.with('tf:output_json', 'tfdir')
-      aproc = Proc { |a, b| after_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       subject.instance_variable_set('@after_proc', aproc)
 
       Rake.application['tf:output_json'].invoke

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -12,6 +12,7 @@ require 'rubygems'
 describe TFWrapper::RakeTasks do
   subject do
     allow(Rake.application).to receive(:rakefile).and_return('Rakefile')
+    allow(Rake.application).to receive(:original_dir).and_return('/path/to/rakedir')
     allow(File).to receive(:realpath) { |p| p }
     subj = TFWrapper::RakeTasks.new('tfdir')
     subj.instance_variable_set('@tf_dir', 'tfdir')
@@ -62,6 +63,8 @@ describe TFWrapper::RakeTasks do
       expect(cls.instance_variable_get('@consul_url')).to eq(nil)
       expect(cls.instance_variable_get('@tf_version'))
         .to eq(Gem::Version.new('0.0.0'))
+      expect(cls.instance_variable_get('@before_proc')).to eq(nil)
+      expect(cls.instance_variable_get('@after_proc')).to eq(nil)
     end
     it 'sets options' do
       allow(ENV).to receive(:[])
@@ -69,12 +72,22 @@ describe TFWrapper::RakeTasks do
       allow(Rake.application).to receive(:rakefile)
         .and_return('/path/to')
       allow(File).to receive(:realpath) { |p| p.sub('../', '') }
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to_not receive(:foo)
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to_not receive(:foo)
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
       cls = TFWrapper::RakeTasks.new(
         'tf/dir',
         consul_env_vars_prefix: 'cvprefix',
         tf_vars_from_env: { 'foo' => 'bar' },
         tf_extra_vars: { 'baz' => 'blam' },
-        consul_url: 'foobar'
+        consul_url: 'foobar',
+        before_proc: bproc,
+        after_proc: aproc
       )
       expect(cls.instance_variable_get('@tf_dir'))
         .to eq('/path/to/tf/dir')
@@ -86,6 +99,36 @@ describe TFWrapper::RakeTasks do
         .to eq('baz' => 'blam')
       expect(cls.instance_variable_get('@backend_config')).to eq({})
       expect(cls.instance_variable_get('@consul_url')).to eq('foobar')
+      expect(cls.instance_variable_get('@before_proc')).to eq(bproc)
+      expect(cls.instance_variable_get('@after_proc')).to eq(aproc)
+    end
+    context 'when before_proc is not a proc or nil' do
+      it 'raises an error' do
+        allow(ENV).to receive(:[])
+        allow(ENV).to receive(:[]).with('CONSUL_HOST').and_return('chost')
+        allow(ENV).to receive(:[]).with('ENVIRONMENT').and_return('myenv')
+        allow(ENV).to receive(:[]).with('PROJECT').and_return('myproj')
+        allow(Rake.application).to receive(:rakefile)
+          .and_return('/rake/dir/Rakefile')
+        allow(File).to receive(:realpath) { |p| p.sub('../', '') }
+        allow(File).to receive(:file?).and_return(true)
+        expect { TFWrapper::RakeTasks.new('tfdir', before_proc: "foo") }.to
+          raise_error(TypeError, /before_proc must be a Proc instance, not a String/)
+      end
+    end
+    context 'when after_proc is not a proc or nil' do
+      it 'raises an error' do
+        allow(ENV).to receive(:[])
+        allow(ENV).to receive(:[]).with('CONSUL_HOST').and_return('chost')
+        allow(ENV).to receive(:[]).with('ENVIRONMENT').and_return('myenv')
+        allow(ENV).to receive(:[]).with('PROJECT').and_return('myproj')
+        allow(Rake.application).to receive(:rakefile)
+          .and_return('/rake/dir/Rakefile')
+        allow(File).to receive(:realpath) { |p| p.sub('../', '') }
+        allow(File).to receive(:file?).and_return(true)
+        expect { TFWrapper::RakeTasks.new('tfdir', after_proc: "foo") }.to
+          raise_error(TypeError, /after_proc must be a Proc instance, not a String/)
+      end
     end
     context 'when consul_url is nil but consul_env_vars_prefix is not' do
       it 'raises an error' do
@@ -290,6 +333,40 @@ describe TFWrapper::RakeTasks do
       expect(subject.instance_variable_get(:@tf_version))
         .to eq(Gem::Version.new('0.10.2'))
     end
+    it 'calls before_proc if not nil' do
+      Rake.application['tf:init'].clear_prerequisites
+
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to receive(:foo).once.with('tf:init', 'tfdir')
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      subject.instance_variable_set('@before_proc', bproc)
+
+      allow(TFWrapper::Helpers).to receive(:check_env_vars)
+      allow(ENV).to receive(:[])
+      subject.instance_variable_set('@backend_config', {})
+      allow(subject).to receive(:terraform_runner)
+      allow(subject).to receive(:check_tf_version)
+        .and_return(Gem::Version.new('0.10.2'))
+      Rake.application['tf:init'].invoke
+    end
+    it 'calls after_proc if not nil' do
+      Rake.application['tf:init'].clear_prerequisites
+
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to receive(:foo).once.with('tf:init', 'tfdir')
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      subject.instance_variable_set('@after_proc', aproc)
+
+      allow(TFWrapper::Helpers).to receive(:check_env_vars)
+      allow(ENV).to receive(:[])
+      subject.instance_variable_set('@backend_config', {})
+      allow(subject).to receive(:terraform_runner)
+      allow(subject).to receive(:check_tf_version)
+        .and_return(Gem::Version.new('0.10.2'))
+      Rake.application['tf:init'].invoke
+    end
   end
   describe '#install_plan' do
     # these let/before/after come from bundler's gem_helper_spec.rb
@@ -339,6 +416,32 @@ describe TFWrapper::RakeTasks do
         'tar.get[1]', 't.gt[2]', 'my.target[3]'
       )
     end
+    it 'calls before_proc if not nil' do
+      Rake.application['tf:plan'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to receive(:foo).once.with('tf:plan', 'tfdir')
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      subject.instance_variable_set('@before_proc', bproc)
+
+      Rake.application['tf:plan'].invoke
+    end
+    it 'calls after_proc if not nil' do
+      Rake.application['tf:plan'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to receive(:foo).once.with('tf:plan', 'tfdir')
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      subject.instance_variable_set('@after_proc', aproc)
+
+      Rake.application['tf:plan'].invoke
+    end
   end
   describe '#install_apply' do
     # these let/before/after come from bundler's gem_helper_spec.rb
@@ -358,6 +461,34 @@ describe TFWrapper::RakeTasks do
       expect(Rake.application['tf:apply'].prerequisites)
         .to eq(%w[tf:init tf:write_tf_vars tf:plan])
       expect(Rake.application['tf:apply'].arg_names).to eq([:target])
+    end
+    it 'calls before_proc if not nil' do
+      Rake.application['tf:apply'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+      allow(subject).to receive(:update_consul_stack_env_vars)
+
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to receive(:foo).once.with('tf:apply', 'tfdir')
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      subject.instance_variable_set('@before_proc', bproc)
+
+      Rake.application['tf:apply'].invoke
+    end
+    it 'calls after_proc if not nil' do
+      Rake.application['tf:apply'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+      allow(subject).to receive(:update_consul_stack_env_vars)
+
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to receive(:foo).once.with('tf:apply', 'tfdir')
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      subject.instance_variable_set('@after_proc', aproc)
+
+      Rake.application['tf:apply'].invoke
     end
     context 'terraform version 0.9.5' do
       before(:each) do
@@ -481,6 +612,32 @@ describe TFWrapper::RakeTasks do
         .with('terraform refresh -var-file file.tfvars.json')
       Rake.application['tf:refresh'].invoke
     end
+    it 'calls before_proc if not nil' do
+      Rake.application['tf:refresh'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to receive(:foo).once.with('tf:refresh', 'tfdir')
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      subject.instance_variable_set('@before_proc', bproc)
+
+      Rake.application['tf:refresh'].invoke
+    end
+    it 'calls after_proc if not nil' do
+      Rake.application['tf:refresh'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to receive(:foo).once.with('tf:refresh', 'tfdir')
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      subject.instance_variable_set('@after_proc', aproc)
+
+      Rake.application['tf:refresh'].invoke
+    end
   end
   describe '#install_destroy' do
     # these let/before/after come from bundler's gem_helper_spec.rb
@@ -530,6 +687,32 @@ describe TFWrapper::RakeTasks do
         'tar.get[1]', 't.gt[2]', 'my.target[3]'
       )
     end
+    it 'calls before_proc if not nil' do
+      Rake.application['tf:destroy'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to receive(:foo).once.with('tf:destroy', 'tfdir')
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      subject.instance_variable_set('@before_proc', bproc)
+
+      Rake.application['tf:destroy'].invoke
+    end
+    it 'calls after_proc if not nil' do
+      Rake.application['tf:destroy'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to receive(:foo).once.with('tf:destroy', 'tfdir')
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      subject.instance_variable_set('@after_proc', aproc)
+
+      Rake.application['tf:destroy'].invoke
+    end
   end
   describe '#install_write_tf_vars' do
     # these let/before/after come from bundler's gem_helper_spec.rb
@@ -573,6 +756,46 @@ describe TFWrapper::RakeTasks do
         expect(f_dbl).to receive(:write).once.with(vars.to_json)
         expect(STDERR).to receive(:puts)
           .once.with('Terraform vars written to: file.tfvars.json')
+        Rake.application['tf:write_tf_vars'].invoke
+      end
+      it 'calls before_proc if not nil' do
+        vars = {
+          'foo' => 'bar',
+          'baz' => 'blam',
+          'aws_access_key' => 'ak'
+        }
+        allow(subject).to receive(:terraform_vars).and_return(vars)
+        allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+        f_dbl = double(File)
+        allow(File).to receive(:open).and_yield(f_dbl)
+        allow(f_dbl).to receive(:write)
+
+        before_dbl = double()
+        allow(before_dbl).to receive(:foo)
+        expect(before_dbl).to receive(:foo).once.with('tf:write_tf_vars', 'tfdir')
+        bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+        subject.instance_variable_set('@before_proc', bproc)
+
+        Rake.application['tf:write_tf_vars'].invoke
+      end
+      it 'calls after_proc if not nil' do
+        vars = {
+          'foo' => 'bar',
+          'baz' => 'blam',
+          'aws_access_key' => 'ak'
+        }
+        allow(subject).to receive(:terraform_vars).and_return(vars)
+        allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+        f_dbl = double(File)
+        allow(File).to receive(:open).and_yield(f_dbl)
+        allow(f_dbl).to receive(:write)
+
+        after_dbl = double()
+        allow(after_dbl).to receive(:foo)
+        expect(after_dbl).to receive(:foo).once.with('tf:write_tf_vars', 'tfdir')
+        aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+        subject.instance_variable_set('@after_proc', aproc)
+
         Rake.application['tf:write_tf_vars'].invoke
       end
     end
@@ -620,6 +843,48 @@ describe TFWrapper::RakeTasks do
           .once.with('Terraform vars written to: foo_file.tfvars.json')
         Rake.application['foo_tf:write_tf_vars'].invoke
       end
+      it 'calls before_proc if not nil' do
+        vars = {
+          'foo' => 'bar',
+          'baz' => 'blam',
+          'aws_access_key' => 'ak'
+        }
+        allow(subject).to receive(:terraform_vars).and_return(vars)
+        allow(subject).to receive(:var_file_path)
+          .and_return('foo_file.tfvars.json')
+        f_dbl = double(File)
+        allow(File).to receive(:open).and_yield(f_dbl)
+        allow(f_dbl).to receive(:write)
+
+        before_dbl = double()
+        allow(before_dbl).to receive(:foo)
+        expect(before_dbl).to receive(:foo).once.with('foo_tf:write_tf_vars', 'tfdir')
+        bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+        subject.instance_variable_set('@before_proc', bproc)
+
+        Rake.application['foo_tf:write_tf_vars'].invoke
+      end
+      it 'calls after_proc if not nil' do
+        vars = {
+          'foo' => 'bar',
+          'baz' => 'blam',
+          'aws_access_key' => 'ak'
+        }
+        allow(subject).to receive(:terraform_vars).and_return(vars)
+        allow(subject).to receive(:var_file_path)
+          .and_return('foo_file.tfvars.json')
+        f_dbl = double(File)
+        allow(File).to receive(:open).and_yield(f_dbl)
+        allow(f_dbl).to receive(:write)
+
+        after_dbl = double()
+        allow(after_dbl).to receive(:foo)
+        expect(after_dbl).to receive(:foo).once.with('foo_tf:write_tf_vars', 'tfdir')
+        aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+        subject.instance_variable_set('@after_proc', aproc)
+
+        Rake.application['foo_tf:write_tf_vars'].invoke
+      end
     end
   end
   describe '#install_output' do
@@ -649,6 +914,32 @@ describe TFWrapper::RakeTasks do
         .with('terraform output')
       Rake.application['tf:output'].invoke
     end
+    it 'output calls before_proc if not nil' do
+      Rake.application['tf:output'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to receive(:foo).once.with('tf:output', 'tfdir')
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      subject.instance_variable_set('@before_proc', bproc)
+
+      Rake.application['tf:output'].invoke
+    end
+    it 'output calls after_proc if not nil' do
+      Rake.application['tf:output'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to receive(:foo).once.with('tf:output', 'tfdir')
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      subject.instance_variable_set('@after_proc', aproc)
+
+      Rake.application['tf:output'].invoke
+    end
     it 'adds the output_json task' do
       expect(Rake.application['tf:output_json']).to be_instance_of(Rake::Task)
       expect(Rake.application['tf:output_json'].prerequisites)
@@ -660,6 +951,32 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:terraform_runner)
       expect(subject).to receive(:terraform_runner).once
         .with('terraform output -json')
+      Rake.application['tf:output_json'].invoke
+    end
+    it 'output_json calls before_proc if not nil' do
+      Rake.application['tf:output'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      before_dbl = double()
+      allow(before_dbl).to receive(:foo)
+      expect(before_dbl).to receive(:foo).once.with('tf:output_json', 'tfdir')
+      bproc = Proc.new { |a, b| before_dbl.foo(a, b) }
+      subject.instance_variable_set('@before_proc', bproc)
+
+      Rake.application['tf:output_json'].invoke
+    end
+    it 'output_json calls after_proc if not nil' do
+      Rake.application['tf:output'].clear_prerequisites
+      allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
+      allow(subject).to receive(:terraform_runner)
+
+      after_dbl = double()
+      allow(after_dbl).to receive(:foo)
+      expect(after_dbl).to receive(:foo).once.with('tf:output_json', 'tfdir')
+      aproc = Proc.new { |a, b| after_dbl.foo(a, b) }
+      subject.instance_variable_set('@after_proc', aproc)
+
       Rake.application['tf:output_json'].invoke
     end
   end


### PR DESCRIPTION
This adds two new options to ``TFWrapper::RakeTasks#initialize`` / ``TFWrapper::RakeTasks.install_tasks``, ``:before_proc`` and ``:after_proc``. They're used to execute arbitrary user code at the beginning and/or end of each task, and are passed the ``tf_dir`` option and the full name of the task (including namespace). These were prompted by my personal use (directly from the command line), but could prove useful in Jenkins as well.

Some examples of use; this one will run 'tfenv install' in the right directory before init, and will display the full state file to STDOUT after successful apply.

```ruby
TFWrapper::RakeTasks.install_tasks(
  '.',
  before_proc: Proc.new do |taskname, tfdir|
    next unless taskname.end_with?(':init')
    TFWrapper::Helpers.run_cmd_stream_output('tfenv install', tfdir)
  end,
  after_proc: Proc.new do |taskname, tfdir|
    next unless taskname.end_with?(':apply')
    TFWrapper::Helpers.run_cmd_stream_output('terraform state pull', tfdir)
  end
)
```

This also includes a bit of doc cleanup.