### PR TITLE
update rubocop and yard versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.0
+
 Metrics/AbcSize:
   Max: 40
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 Version 0.4.1
 
-  - Upgrade rubocop and yard development dependency versions
+  - Upgrade rubocop, yard and diplomat development dependency versions
   - Pin `cri` development dependency to 2.9 to retain ruby 2.0 support
 
 Version 0.4.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 Version 0.4.1
 
   - Upgrade rubocop and yard development dependency versions
+  - Pin `cri` development dependency to 2.9 to retain ruby 2.0 support
 
 Version 0.4.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+Version 0.4.1
+
+  - Upgrade rubocop and yard development dependency versions
+
 Version 0.4.0
 
   - Add support for calling Procs at the beginning and end of each task.

--- a/lib/tfwrapper/version.rb
+++ b/lib/tfwrapper/version.rb
@@ -4,5 +4,5 @@ module TFWrapper
   # version of the Gem/module; used in the gemspec and in messages.
   # NOTE: When updating this, also update the version in the "Installation"
   # section of README.md
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -8,11 +8,11 @@ require 'json'
 TF_VERSION = desired_tf_version
 if Gem::Version.new(TF_VERSION) >= Gem::Version.new('0.10.0')
   APPLY_CMD = 'terraform apply -auto-approve'
-  if Gem::Version.new(TF_VERSION) >= Gem::Version.new('0.11.0')
-    EXPECTED_SERIAL = 1
-  else
-    EXPECTED_SERIAL = 2
-  end
+  EXPECTED_SERIAL = if Gem::Version.new(TF_VERSION) < Gem::Version.new('0.11.0')
+                      2
+                    else
+                      1
+                    end
 else
   EXPECTED_SERIAL = 1
   APPLY_CMD = 'terraform apply'

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -7,8 +7,12 @@ require 'json'
 
 TF_VERSION = desired_tf_version
 if Gem::Version.new(TF_VERSION) >= Gem::Version.new('0.10.0')
-  EXPECTED_SERIAL = 2
   APPLY_CMD = 'terraform apply -auto-approve'
+  if Gem::Version.new(TF_VERSION) >= Gem::Version.new('0.11.0')
+    EXPECTED_SERIAL = 1
+  else
+    EXPECTED_SERIAL = 2
+  end
 else
   EXPECTED_SERIAL = 1
   APPLY_CMD = 'terraform apply'

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -1202,17 +1202,12 @@ describe TFWrapper::RakeTasks do
         subject.instance_variable_set('@tf_vars_from_env', vars)
         subject.instance_variable_set('@consul_url', 'foo://bar')
         subject.instance_variable_set('@consul_env_vars_prefix', 'my/prefix')
-        dbl_config = double
-        allow(dbl_config).to receive(:url=)
-        allow(Diplomat).to receive(:configure).and_yield(dbl_config)
         allow(ENV).to receive(:[])
         allow(ENV).to receive(:[]).with('CONSUL_HOST').and_return('chost')
         allow(ENV).to receive(:[]).with('bar').and_return('barVal')
         allow(ENV).to receive(:[]).with('blam').and_return('blamVal')
         allow(Diplomat::Kv).to receive(:put)
 
-        expect(Diplomat).to receive(:configure).once
-        expect(dbl_config).to receive(:url=).once.with('foo://bar')
         expect(STDOUT).to receive(:puts).once
           .with('Writing stack information to foo://bar at: my/prefix')
         expect(STDOUT).to receive(:puts).once
@@ -1220,6 +1215,7 @@ describe TFWrapper::RakeTasks do
         expect(Diplomat::Kv).to receive(:put)
           .once.with('my/prefix', JSON.generate(expected))
         subject.update_consul_stack_env_vars
+        expect(Diplomat.configuration.url).to eq('foo://bar')
       end
     end
   end

--- a/tfwrapper.gemspec
+++ b/tfwrapper.gemspec
@@ -42,10 +42,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10'
   gem.add_development_dependency 'rspec', '~> 3'
   gem.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
-  gem.add_development_dependency 'rubocop', '~> 0.37'
+  gem.add_development_dependency 'rubocop', '~> 0.49.1'
   gem.add_development_dependency 'simplecov', '~> 0.11'
   gem.add_development_dependency 'simplecov-console'
-  gem.add_development_dependency 'yard', '~> 0.8'
+  gem.add_development_dependency 'yard', '~> 0.9.11'
 
   # this requires rubygems >= 2.2.0
   gem.metadata['allowed_push_host'] = 'https://rubygems.org'

--- a/tfwrapper.gemspec
+++ b/tfwrapper.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'cri', '~> 2.9.1'
-  gem.add_development_dependency 'diplomat', '~> 0.15'
+  gem.add_development_dependency 'diplomat', '~> 2.0.2'
   gem.add_development_dependency 'faraday', '~> 0.9'
   gem.add_development_dependency 'ffi', '>= 1.9.9'
   gem.add_development_dependency 'git', '~> 1.2', '>= 1.2.9.1'

--- a/tfwrapper.gemspec
+++ b/tfwrapper.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rb-readline', '~> 0.5'
 
   gem.add_development_dependency 'bundler'
-  gem.add_development_dependency 'cri', '~> 2'
+  gem.add_development_dependency 'cri', '~> 2.9.1'
   gem.add_development_dependency 'diplomat', '~> 0.15'
   gem.add_development_dependency 'faraday', '~> 0.9'
   gem.add_development_dependency 'ffi', '>= 1.9.9'


### PR DESCRIPTION
GitHub's [Network dependencies](https://github.com/manheim/tfwrapper/network/dependencies) shows that this project has two dependencies with open CVEs, rubocop and yard. Both are development dependencies and only executed during tests, so there shouldn't be any real risk, but it's probably good to upgrade them to non-vulnerable versions.

We needed a minor change to `.rubocop.yml` to work around changes introduced by the upgrade.