### PR TITLE
Terraform-Landscape Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /vendor/
 .terraform
 build.tfvars.json
+**/*_build.tfvars.json
 **/terraform.tfstate.backup
 
 # Used by dotenv library to load environment variables.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,10 +2,10 @@ AllCops:
   TargetRubyVersion: 2.0
 
 Metrics/AbcSize:
-  Max: 40
+  Max: 50
 
 Metrics/BlockLength:
-  Max: 1300
+  Max: 1400
 
 Metrics/ClassLength:
   Max: 500
@@ -14,10 +14,10 @@ Metrics/MethodLength:
   Max: 100
 
 Metrics/PerceivedComplexity:
-  Max: 8
+  Max: 10
 
 Metrics/CyclomaticComplexity:
-  Max: 8
+  Max: 10
 
 # These are to compensate for some warnings that differ by
 # rubocop/ruby version
@@ -30,7 +30,7 @@ Style/MutableConstant:
     - 'lib/tfwrapper/version.rb'
     - 'spec/acceptance/acceptance_spec.rb'
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Exclude:
     - 'spec/unit/raketasks_spec.rb'
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+Version 0.5.0
+
+  - Add support for using terraform_landscape gem, if present, to reformat plan output; see README for usage.
+  - Add CircleCI testing under ruby 2.4.1, and acceptance tests for terraform 0.11.2.
+
 Version 0.4.1
 
   - Upgrade rubocop, yard and diplomat development dependency versions

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@
 
 source 'https://rubygems.org'
 gemspec
+
+group :landscape do
+  gem 'terraform_landscape'
+end

--- a/circle.yml
+++ b/circle.yml
@@ -5,11 +5,11 @@ dependencies:
   pre:
     - sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install git
   override:
-    - 'bundle install'
-    - 'rvm 2.0.0-p598 exec bundle install'
-    - 'rvm 2.1.8 exec bundle install'
-    - 'rvm 2.2.5 exec bundle install'
-    - 'rvm 2.3.1 exec bundle install'
+    - 'bundle install --without landscape'
+    - 'rvm 2.0.0-p598 exec bundle install --without landscape'
+    - 'rvm 2.1.8 exec bundle install --without landscape'
+    - 'rvm 2.2.5 exec bundle install --without landscape'
+    - 'rvm 2.3.1 exec bundle install --without landscape'
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -27,5 +27,6 @@ test:
     - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.10.0'
     - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.10.2'
     - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.11.2'
-    - 'rvm 2.4.1 exec bundle exec rake spec:acceptance TF_VERSION=latest'
+    - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=latest'
+    - 'rvm 2.4.1 exec bundle exec rake spec:acceptance TF_VERSION=0.11.2'
     - 'bundle exec rake yard:generate'

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
     - 'rvm 2.1.8 exec bundle install --without landscape'
     - 'rvm 2.2.5 exec bundle install --without landscape'
     - 'rvm 2.3.1 exec bundle install --without landscape'
+    - 'rvm 2.4.1 exec bundle install'
 
 test:
   override:
@@ -20,9 +21,11 @@ test:
     - 'rvm 2.1.8 exec bundle exec rake spec:unit'
     - 'rvm 2.2.5 exec bundle exec rake spec:unit'
     - 'rvm 2.3.1 exec bundle exec rake spec:unit'
+    - 'rvm 2.4.1 exec bundle exec rake spec:unit'
     - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.9.2'
     - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.9.7'
     - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.10.0'
     - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.10.2'
-    - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=latest'
+    - 'rvm 2.3.1 exec bundle exec rake spec:acceptance TF_VERSION=0.11.2'
+    - 'rvm 2.4.1 exec bundle exec rake spec:acceptance TF_VERSION=latest'
     - 'bundle exec rake yard:generate'

--- a/lib/tfwrapper/helpers.rb
+++ b/lib/tfwrapper/helpers.rb
@@ -69,6 +69,7 @@ module TFWrapper
       end
       # rubocop:disable Style/RedundantReturn
       $stdout.sync = old_sync
+      puts '' if stream_type == :dots
       return all_out_err, exit_status
       # rubocop:enable Style/RedundantReturn
     end

--- a/lib/tfwrapper/helpers.rb
+++ b/lib/tfwrapper/helpers.rb
@@ -31,8 +31,20 @@ module TFWrapper
     #
     # @param cmd [String] command to run
     # @param pwd [String] directory/path to run command in
+    # @option opts [Hash] :progress How to handle streaming output. Possible
+    #  values are ``:stream`` (default) to stream each line in STDOUT/STDERR
+    #  to STDOUT, ``:dots`` to print a dot for each line, ``:lines`` to print
+    #  a dot followed by a newline for each line, or ``nil`` to not stream any
+    #  output at all.
     # @return [Array] - out_err [String], exit code [Fixnum]
-    def self.run_cmd_stream_output(cmd, pwd)
+    def self.run_cmd_stream_output(cmd, pwd, opts = {})
+      stream_type = opts.fetch(:progress, :stream)
+      unless [:dots, :lines, :stream, nil].include?(stream_type)
+        raise(
+          ArgumentError,
+          'progress option must be one of: [:dots, :lines, :stream, nil]'
+        )
+      end
       old_sync = $stdout.sync
       $stdout.sync = true
       all_out_err = ''.dup
@@ -41,7 +53,13 @@ module TFWrapper
         stdin.close_write
         begin
           while (line = stdout_and_err.gets)
-            puts line
+            if stream_type == :stream
+              puts line
+            elsif stream_type == :dots
+              STDOUT.print '.'
+            elsif stream_type == :lines
+              puts '.'
+            end
             all_out_err << line
           end
         rescue IOError => e

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -339,16 +339,14 @@ module TFWrapper
     # Given a string of terraform plan output, format it with
     # terraform_landscape and print the result to STDOUT.
     def landscape_format(output)
-      begin
-        p = TerraformLandscape::Printer.new(
-          TerraformLandscape::Output.new(STDOUT)
-        )
-        p.process_string(output)
-      rescue Exception => ex
-        STDERR.puts "Exception calling terraform_landscape to reformat " \
-                    "output: #{ex.class.name}: #{ex}"
-        puts output unless @landscape_progress == :stream
-      end
+      p = TerraformLandscape::Printer.new(
+        TerraformLandscape::Output.new(STDOUT)
+      )
+      p.process_string(output)
+    rescue StandardError, ScriptError => ex
+      STDERR.puts 'Exception calling terraform_landscape to reformat ' \
+                  "output: #{ex.class.name}: #{ex}"
+      puts output unless @landscape_progress == :stream
     end
 
     # Run a Terraform command, providing some useful output and handling AWS

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -10,7 +10,7 @@ require 'tfwrapper/version'
 begin
   require 'terraform_landscape'
   HAVE_LANDSCAPE = true
-rescue
+rescue LoadError
   HAVE_LANDSCAPE = false
 end
 # :nocov:

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -388,7 +388,7 @@ module TFWrapper
         # this streams STDOUT and STDERR as a combined stream,
         # and also captures them as a combined string
         out_err, status = TFWrapper::Helpers.run_cmd_stream_output(
-          cmd, @tf_dir, stream_type: stream_type
+          cmd, @tf_dir, progress: stream_type
         )
         if status != 0 && out_err.include?('hrottling')
           raise StandardError, 'Terraform hit AWS API rate limiting'

--- a/lib/tfwrapper/version.rb
+++ b/lib/tfwrapper/version.rb
@@ -4,5 +4,5 @@ module TFWrapper
   # version of the Gem/module; used in the gemspec and in messages.
   # NOTE: When updating this, also update the version in the "Installation"
   # section of README.md
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
 end

--- a/spec/acceptance/acceptance_helpers.rb
+++ b/spec/acceptance/acceptance_helpers.rb
@@ -24,10 +24,22 @@ def desired_tf_version
     return ENV['TF_VERSION']
   end
   # else get the latest release from GitHub
+  latest_tf_version
+end
+
+def latest_tf_version
   resp = Faraday.get('https://api.github.com/repos/hashicorp/terraform/releases/latest')
   rel = JSON.parse(resp.body)['tag_name'].sub(/^v/, '')
   puts "Found latest terraform release on GitHub: #{rel}"
   rel
+end
+
+# Given the example terraform plan output with placeholders for the
+# latest terraform version and fixtures path, return the interpolated string.
+def clean_tf_plan_output(raw_out, latest_ver, fixture_path)
+  raw_out
+    .gsub('%%TF_LATEST_VER%%', latest_ver)
+    .gsub('%%FIXTUREPATH%%', fixture_path)
 end
 
 class HashicorpFetcher

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -753,7 +753,7 @@ describe 'tfwrapper' do
         File.read(File.join(@fixturepath, 'state.json'))
       )
     end
-    context 'without landscape installed' , if: without_landscape  do
+    context 'without landscape installed', if: without_landscape do
       describe 'default_tf:plan' do
         before(:all) do
           @out_err, @ecode = Open3.capture2e(
@@ -858,7 +858,6 @@ describe 'tfwrapper' do
             expect(@ecode.exitstatus).to eq(0)
           end
           it 'returns progress dots for plan output and landscape output' do
-            File.open(File.join(@fixturepath, 'with_landscape_dots.out'), 'w') { |f| f.write(@out_err) }
             expected = clean_tf_plan_output(
               File.read(File.join(@fixturepath, 'with_landscape_dots.out')),
               latest_tf_ver, @fixturepath
@@ -887,7 +886,6 @@ describe 'tfwrapper' do
             expect(@ecode.exitstatus).to eq(0)
           end
           it 'returns progress lines for plan output and landscape output' do
-            File.open(File.join(@fixturepath, 'with_landscape_lines.out'), 'w') { |f| f.write(@out_err) }
             expected = clean_tf_plan_output(
               File.read(File.join(@fixturepath, 'with_landscape_lines.out')),
               latest_tf_ver, @fixturepath

--- a/spec/fixtures/landscapeTest/Rakefile
+++ b/spec/fixtures/landscapeTest/Rakefile
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'tfwrapper/raketasks'
+
+TFWrapper::RakeTasks.install_tasks(
+  '.',
+  namespace_prefix: 'default',
+)
+
+TFWrapper::RakeTasks.install_tasks(
+  '.',
+  namespace_prefix: 'disabled',
+  disable_landscape: true
+)
+
+TFWrapper::RakeTasks.install_tasks(
+  '.',
+  namespace_prefix: 'stream',
+  landscape_progress: :stream
+)
+
+TFWrapper::RakeTasks.install_tasks(
+  '.',
+  namespace_prefix: 'dots',
+  landscape_progress: :dots
+)
+
+TFWrapper::RakeTasks.install_tasks(
+  '.',
+  namespace_prefix: 'lines',
+  landscape_progress: :lines
+)

--- a/spec/fixtures/landscapeTest/Rakefile
+++ b/spec/fixtures/landscapeTest/Rakefile
@@ -4,7 +4,7 @@ require 'tfwrapper/raketasks'
 
 TFWrapper::RakeTasks.install_tasks(
   '.',
-  namespace_prefix: 'default',
+  namespace_prefix: 'default'
 )
 
 TFWrapper::RakeTasks.install_tasks(

--- a/spec/fixtures/landscapeTest/main.tf
+++ b/spec/fixtures/landscapeTest/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = "> 0.9.0"
+  backend "consul" {
+    address = "127.0.0.1:8500"
+    path    = "terraform/landscapeTest"
+  }
+}
+
+provider "consul" {
+  address = "127.0.0.1:8500"
+  version = "~> 1.0"
+}
+
+locals {
+  keys = {
+    foo = "foo2val"
+    bar = "bar2val"
+    baz = "baz2val"
+  }
+}
+
+variable "foo" { default = "bar" }
+
+resource "consul_key_prefix" "landscapeTest" {
+  path_prefix = "landscapeTest/"
+
+  subkeys = {
+    foo = "${jsonencode(local.keys)}"
+  }
+}
+
+output "foo_variable" { value = "${var.foo}" }

--- a/spec/fixtures/landscapeTest/state.json
+++ b/spec/fixtures/landscapeTest/state.json
@@ -1,0 +1,43 @@
+{
+    "version": 3,
+    "terraform_version": "0.11.2",
+    "serial": 1,
+    "lineage": "2bab32f5-67fc-4210-8a74-af61d21a5420",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {
+                "foo_variable": {
+                    "sensitive": false,
+                    "type": "string",
+                    "value": "bar"
+                }
+            },
+            "resources": {
+                "consul_key_prefix.landscapeTest": {
+                    "type": "consul_key_prefix",
+                    "depends_on": [
+                        "local.keys"
+                    ],
+                    "primary": {
+                        "id": "landscapeTest/",
+                        "attributes": {
+                            "datacenter": "dc1",
+                            "id": "landscapeTest/",
+                            "path_prefix": "landscapeTest/",
+                            "subkeys.%": "1",
+                            "subkeys.foo": "{\"bar\":\"bar2val\",\"baz\":\"baz2val\",\"foo\":\"foo2val\"}"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.consul"
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}

--- a/spec/fixtures/landscapeTest/with_landscape_default.out
+++ b/spec/fixtures/landscapeTest/with_landscape_default.out
@@ -1,0 +1,45 @@
+Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+terraform_runner command: 'terraform init -input=false' (in %%FIXTUREPATH%%)
+Running with: Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+
+[0m[1mInitializing the backend...[0m
+[0m[32m
+Successfully configured the backend "consul"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "consul" (1.0.0)...
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+terraform_runner command 'terraform init -input=false' finished and exited 0
+Terraform vars written to: %%FIXTUREPATH%%/default_build.tfvars.json
+terraform_runner command: 'terraform plan -var-file %%FIXTUREPATH%%/default_build.tfvars.json' (in %%FIXTUREPATH%%)
+Terraform vars:
+terraform_runner command 'terraform plan -var-file %%FIXTUREPATH%%/default_build.tfvars.json' finished and exited 0
+[0;33;49m~ consul_key_prefix.landscapeTest[0m
+[0;33;49m    subkeys.foo:   [0m{
+                   [31m-  "bar": "barval",[0m
+                   [31m-  "baz": "bazval",[0m
+                   [31m-  "foo": "fooval"[0m
+                   [32m+  "bar": "bar2val",[0m
+                   [32m+  "baz": "baz2val",[0m
+                   [32m+  "foo": "foo2val"[0m
+                    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+

--- a/spec/fixtures/landscapeTest/with_landscape_dots.out
+++ b/spec/fixtures/landscapeTest/with_landscape_dots.out
@@ -1,0 +1,46 @@
+Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+terraform_runner command: 'terraform init -input=false' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest)
+Running with: Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+
+[0m[1mInitializing the backend...[0m
+[0m[32m
+Successfully configured the backend "consul"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "consul" (1.0.0)...
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+terraform_runner command 'terraform init -input=false' finished and exited 0
+Terraform vars written to: /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/dots_build.tfvars.json
+terraform_runner command: 'terraform plan -var-file /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/dots_build.tfvars.json' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest)
+Terraform vars:
+..........................terraform_runner command 'terraform plan -var-file /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/dots_build.tfvars.json' finished and exited 0
+
+[0;33;49m~ consul_key_prefix.landscapeTest[0m
+[0;33;49m    subkeys.foo:   [0m{
+                   [31m-  "bar": "barval",[0m
+                   [31m-  "baz": "bazval",[0m
+                   [31m-  "foo": "fooval"[0m
+                   [32m+  "bar": "bar2val",[0m
+                   [32m+  "baz": "baz2val",[0m
+                   [32m+  "foo": "foo2val"[0m
+                    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+

--- a/spec/fixtures/landscapeTest/with_landscape_lines.out
+++ b/spec/fixtures/landscapeTest/with_landscape_lines.out
@@ -1,0 +1,71 @@
+Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+terraform_runner command: 'terraform init -input=false' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest)
+Running with: Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+
+[0m[1mInitializing the backend...[0m
+[0m[32m
+Successfully configured the backend "consul"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "consul" (1.0.0)...
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+terraform_runner command 'terraform init -input=false' finished and exited 0
+Terraform vars written to: /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/lines_build.tfvars.json
+terraform_runner command: 'terraform plan -var-file /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/lines_build.tfvars.json' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest)
+Terraform vars:
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+terraform_runner command 'terraform plan -var-file /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/lines_build.tfvars.json' finished and exited 0
+[0;33;49m~ consul_key_prefix.landscapeTest[0m
+[0;33;49m    subkeys.foo:   [0m{
+                   [31m-  "bar": "barval",[0m
+                   [31m-  "baz": "bazval",[0m
+                   [31m-  "foo": "fooval"[0m
+                   [32m+  "bar": "bar2val",[0m
+                   [32m+  "baz": "baz2val",[0m
+                   [32m+  "foo": "foo2val"[0m
+                    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+

--- a/spec/fixtures/landscapeTest/with_landscape_stream.out
+++ b/spec/fixtures/landscapeTest/with_landscape_stream.out
@@ -1,0 +1,71 @@
+Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+terraform_runner command: 'terraform init -input=false' (in %%FIXTUREPATH%%)
+Running with: Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+
+[0m[1mInitializing the backend...[0m
+[0m[32m
+Successfully configured the backend "consul"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "consul" (1.0.0)...
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+terraform_runner command 'terraform init -input=false' finished and exited 0
+Terraform vars written to: %%FIXTUREPATH%%/stream_build.tfvars.json
+terraform_runner command: 'terraform plan -var-file %%FIXTUREPATH%%/stream_build.tfvars.json' (in %%FIXTUREPATH%%)
+Terraform vars:
+[0m[1mRefreshing Terraform state in-memory prior to plan...[0m
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+[0m
+[0m[1mconsul_key_prefix.landscapeTest: Refreshing state... (ID: landscapeTest/)[0m
+
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  [33m~[0m update in-place
+[0m
+Terraform will perform the following actions:
+
+[33m  [33m~[0m [33mconsul_key_prefix.landscapeTest
+[0m      subkeys.foo: "{\"bar\":\"barval\",\"baz\":\"bazval\",\"foo\":\"fooval\"}" => "{\"bar\":\"bar2val\",\"baz\":\"baz2val\",\"foo\":\"foo2val\"}"
+[0m
+[0m
+[0m[1mPlan:[0m 0 to add, 1 to change, 0 to destroy.[0m
+
+------------------------------------------------------------------------
+
+Note: You didn't specify an "-out" parameter to save this plan, so Terraform
+can't guarantee that exactly these actions will be performed if
+"terraform apply" is subsequently run.
+
+terraform_runner command 'terraform plan -var-file %%FIXTUREPATH%%/stream_build.tfvars.json' finished and exited 0
+[0;33;49m~ consul_key_prefix.landscapeTest[0m
+[0;33;49m    subkeys.foo:   [0m{
+                   [31m-  "bar": "barval",[0m
+                   [31m-  "baz": "bazval",[0m
+                   [31m-  "foo": "fooval"[0m
+                   [32m+  "bar": "bar2val",[0m
+                   [32m+  "baz": "baz2val",[0m
+                   [32m+  "foo": "foo2val"[0m
+                    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+

--- a/spec/fixtures/landscapeTest/without_landscape.out
+++ b/spec/fixtures/landscapeTest/without_landscape.out
@@ -1,0 +1,62 @@
+Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+terraform_runner command: 'terraform init -input=false' (in %%FIXTUREPATH%%)
+Running with: Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+
+[0m[1mInitializing the backend...[0m
+[0m[32m
+Successfully configured the backend "consul"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "consul" (1.0.0)...
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+terraform_runner command 'terraform init -input=false' finished and exited 0
+Terraform vars written to: %%FIXTUREPATH%%/default_build.tfvars.json
+terraform_runner command: 'terraform plan -var-file %%FIXTUREPATH%%/default_build.tfvars.json' (in %%FIXTUREPATH%%)
+Terraform vars:
+[0m[1mRefreshing Terraform state in-memory prior to plan...[0m
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+[0m
+
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  [32m+[0m create
+[0m
+Terraform will perform the following actions:
+
+[32m  [32m+[0m [32mconsul_key_prefix.landscapeTest
+[0m      id:          <computed>
+      datacenter:  <computed>
+      path_prefix: "landscapeTest/"
+      subkeys.%:   "1"
+      subkeys.foo: "{\"bar\":\"bar2val\",\"baz\":\"baz2val\",\"foo\":\"foo2val\"}"
+[0m
+[0m
+[0m[1mPlan:[0m 1 to add, 0 to change, 0 to destroy.[0m
+
+------------------------------------------------------------------------
+
+Note: You didn't specify an "-out" parameter to save this plan, so Terraform
+can't guarantee that exactly these actions will be performed if
+"terraform apply" is subsequently run.
+
+terraform_runner command 'terraform plan -var-file %%FIXTUREPATH%%/default_build.tfvars.json' finished and exited 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,13 @@ require 'simplecov'
 require 'simplecov-console'
 require 'rspec_junit_formatter'
 
+begin
+  require 'terraform_landscape'
+  HAVE_LANDSCAPE = true
+rescue LoadError
+  HAVE_LANDSCAPE = false
+end
+
 ENV['CONSUL_ADDR'] ||= '127.0.0.1:8500'
 ENV['CONSUL_URL']  ||= "http://#{ENV['CONSUL_ADDR']}"
 

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -201,11 +201,11 @@ describe TFWrapper::Helpers do
         expect(Open3).to_not receive(:popen2e)
         expect(STDOUT).to_not receive(:puts)
         expect($stdout).to_not receive(:sync=)
-        expect {
+        expect do
           TFWrapper::Helpers.run_cmd_stream_output(
             'foo bar', '/foo', progress: :foo
           )
-        }.to raise_error(ArgumentError, /progress option must be one of/)
+        end.to raise_error(ArgumentError, /progress option must be one of/)
       end
     end
   end

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -76,7 +76,7 @@ describe TFWrapper::Helpers do
 
         expect(Open3).to receive(:popen2e)
           .once.with('foo bar', chdir: '/foo')
-        expect(STDOUT).to_not receive(:puts)
+        expect(STDOUT).to receive(:puts).once.with('')
         expect(STDOUT).to receive(:print).once.with('.')
         expect($stdout).to receive(:sync=).once.with(true)
         expect($stdout).to receive(:sync=).once.with(false)

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -54,10 +54,89 @@ describe TFWrapper::Helpers do
         expect(Open3).to receive(:popen2e)
           .once.with('foo bar', chdir: '/foo')
         expect(STDOUT).to receive(:puts).once.with('mystdout')
+        expect(STDOUT).to_not receive(:print)
         expect($stdout).to receive(:sync=).once.with(true)
         expect($stdout).to receive(:sync=).once.with(false)
         expect(TFWrapper::Helpers.run_cmd_stream_output('foo bar', '/foo'))
           .to eq(['mystdout', 0])
+      end
+    end
+    context 'progress dots' do
+      it 'prints dots and returns output' do
+        dbl_wait_thread = double(Thread)
+        @outerrpipe_w.write('mystdout')
+        @outerrpipe_w.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow($stdout).to receive(:sync).and_return(false)
+        allow($stdout).to receive(:sync=).with(true)
+        allow(Open3).to receive(:popen2e).and_yield(
+          @inpipe_w, @outerrpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen2e)
+          .once.with('foo bar', chdir: '/foo')
+        expect(STDOUT).to_not receive(:puts)
+        expect(STDOUT).to receive(:print).once.with('.')
+        expect($stdout).to receive(:sync=).once.with(true)
+        expect($stdout).to receive(:sync=).once.with(false)
+        expect(
+          TFWrapper::Helpers.run_cmd_stream_output(
+            'foo bar', '/foo', progress: :dots
+          )
+        ).to eq(['mystdout', 0])
+      end
+    end
+    context 'progress lines' do
+      it 'prints a dot per line and returns output' do
+        dbl_wait_thread = double(Thread)
+        @outerrpipe_w.write('mystdout')
+        @outerrpipe_w.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow($stdout).to receive(:sync).and_return(false)
+        allow($stdout).to receive(:sync=).with(true)
+        allow(Open3).to receive(:popen2e).and_yield(
+          @inpipe_w, @outerrpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen2e)
+          .once.with('foo bar', chdir: '/foo')
+        expect(STDOUT).to receive(:puts).once.with('.')
+        expect(STDOUT).to_not receive(:print)
+        expect($stdout).to receive(:sync=).once.with(true)
+        expect($stdout).to receive(:sync=).once.with(false)
+        expect(
+          TFWrapper::Helpers.run_cmd_stream_output(
+            'foo bar', '/foo', progress: :lines
+          )
+        ).to eq(['mystdout', 0])
+      end
+    end
+    context 'progress nil' do
+      it 'does not print anything but returns output' do
+        dbl_wait_thread = double(Thread)
+        @outerrpipe_w.write('mystdout')
+        @outerrpipe_w.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow($stdout).to receive(:sync).and_return(false)
+        allow($stdout).to receive(:sync=).with(true)
+        allow(Open3).to receive(:popen2e).and_yield(
+          @inpipe_w, @outerrpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen2e)
+          .once.with('foo bar', chdir: '/foo')
+        expect(STDOUT).to_not receive(:puts)
+        expect(STDOUT).to_not receive(:print)
+        expect($stdout).to receive(:sync=).once.with(true)
+        expect($stdout).to receive(:sync=).once.with(false)
+        expect(
+          TFWrapper::Helpers.run_cmd_stream_output(
+            'foo bar', '/foo', progress: nil
+          )
+        ).to eq(['mystdout', 0])
       end
     end
     context 'IOError' do
@@ -104,6 +183,29 @@ describe TFWrapper::Helpers do
         expect($stdout).to receive(:sync=).once.with(false)
         expect(TFWrapper::Helpers.run_cmd_stream_output('foo bar', '/foo'))
           .to eq(["mystdout\nSTDERR\n", 23])
+      end
+    end
+    context 'invalid :progress option' do
+      it 'raises an error' do
+        dbl_wait_thread = double(Thread)
+        @outerrpipe_w.write('mystdout')
+        @outerrpipe_w.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow($stdout).to receive(:sync).and_return(false)
+        allow($stdout).to receive(:sync=).with(true)
+        allow(Open3).to receive(:popen2e).and_yield(
+          @inpipe_w, @outerrpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to_not receive(:popen2e)
+        expect(STDOUT).to_not receive(:puts)
+        expect($stdout).to_not receive(:sync=)
+        expect {
+          TFWrapper::Helpers.run_cmd_stream_output(
+            'foo bar', '/foo', progress: :foo
+          )
+        }.to raise_error(ArgumentError, /progress option must be one of/)
       end
     end
   end

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -416,6 +416,7 @@ describe TFWrapper::RakeTasks do
       expect(Rake.application['tf:plan'].arg_names).to eq([:target])
     end
     it 'runs the plan command with no targets' do
+      stub_const('TFWrapper::RakeTasks::HAVE_LANDSCAPE', true)
       Rake.application['tf:plan'].clear_prerequisites
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
@@ -424,6 +425,7 @@ describe TFWrapper::RakeTasks do
       Rake.application['tf:plan'].invoke
     end
     it 'runs the plan command with one target' do
+      stub_const('TFWrapper::RakeTasks::HAVE_LANDSCAPE', true)
       Rake.application['tf:plan'].clear_prerequisites
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
@@ -433,6 +435,7 @@ describe TFWrapper::RakeTasks do
       Rake.application['tf:plan'].invoke('tar.get[1]')
     end
     it 'runs the plan command with three targets' do
+      stub_const('TFWrapper::RakeTasks::HAVE_LANDSCAPE', true)
       Rake.application['tf:plan'].clear_prerequisites
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
@@ -1098,7 +1101,7 @@ describe TFWrapper::RakeTasks do
       )
     end
   end
-  describe '#landscape_format' do
+  describe '#landscape_format', :if => HAVE_LANDSCAPE do
     before(:each) do
       allow(STDERR).to receive(:puts)
       allow(STDOUT).to receive(:puts)
@@ -1160,7 +1163,7 @@ describe TFWrapper::RakeTasks do
             .to receive(:new).and_return(dbl_output)
           allow(dbl_printer).to receive(:process_string)
             .and_raise(RuntimeError, "FooError")
-          
+
           expect(TerraformLandscape::Output)
             .to receive(:new).once.with(STDOUT)
           expect(TerraformLandscape::Printer)

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -1191,7 +1191,7 @@ describe TFWrapper::RakeTasks do
       allow(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
         .with(any_args).and_return(['MyOutput', 0])
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .once.with('foo', 'tfdir', stream_type: :stream)
+        .once.with('foo', 'tfdir', progress: :stream)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1207,7 +1207,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(2).times.with('foo', 'tfdir', stream_type: :stream)
+        .exactly(2).times.with('foo', 'tfdir', progress: :stream)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1229,7 +1229,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(3).times.with('foo', 'tfdir', stream_type: :stream)
+        .exactly(3).times.with('foo', 'tfdir', progress: :stream)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1254,7 +1254,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(3).times.with('foo', 'tfdir', stream_type: :dots)
+        .exactly(3).times.with('foo', 'tfdir', progress: :dots)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1281,7 +1281,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(3).times.with('foo', 'tfdir', stream_type: nil)
+        .exactly(3).times.with('foo', 'tfdir', progress: nil)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1300,7 +1300,7 @@ describe TFWrapper::RakeTasks do
       allow(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
         .and_return(['', 1])
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output).once
-        .with('foo', 'tfdir', stream_type: :stream)
+        .with('foo', 'tfdir', progress: :stream)
       expect(STDERR).to receive(:puts).once
         .with('terraform_runner command: \'foo\' (in tfdir)')
       expect { subject.terraform_runner('foo') }

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -421,7 +421,7 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:var_file_path).and_return('file.tfvars.json')
       allow(subject).to receive(:terraform_runner)
       expect(subject).to receive(:terraform_runner).once
-        .with('terraform plan -var-file file.tfvars.json', {progress: nil})
+        .with('terraform plan -var-file file.tfvars.json', progress: nil)
       Rake.application['tf:plan'].invoke
     end
     it 'runs the plan command with one target' do
@@ -431,7 +431,7 @@ describe TFWrapper::RakeTasks do
       allow(subject).to receive(:terraform_runner)
       expect(subject).to receive(:terraform_runner).once
         .with('terraform plan -var-file file.tfvars.json ' \
-              '-target tar.get[1]', {progress: nil})
+              '-target tar.get[1]', progress: nil)
       Rake.application['tf:plan'].invoke('tar.get[1]')
     end
     it 'runs the plan command with three targets' do
@@ -442,7 +442,7 @@ describe TFWrapper::RakeTasks do
       expect(subject).to receive(:terraform_runner).once
         .with('terraform plan -var-file file.tfvars.json ' \
               '-target tar.get[1] -target t.gt[2] -target my.target[3]',
-              {progress: nil})
+              progress: nil)
       Rake.application['tf:plan'].invoke(
         'tar.get[1]', 't.gt[2]', 'my.target[3]'
       )
@@ -456,7 +456,7 @@ describe TFWrapper::RakeTasks do
       it 'runs plan with default progress type' do
         Rake.application['tf:plan'].clear_prerequisites
         expect(subject).to receive(:terraform_runner).once
-          .with('terraform plan -var-file file.tfvars.json', {progress: nil})
+          .with('terraform plan -var-file file.tfvars.json', progress: nil)
         expect(subject).to receive(:landscape_format).once.with('TFoutput')
         Rake.application['tf:plan'].invoke
       end
@@ -464,7 +464,7 @@ describe TFWrapper::RakeTasks do
         Rake.application['tf:plan'].clear_prerequisites
         subject.instance_variable_set('@landscape_progress', :dots)
         expect(subject).to receive(:terraform_runner).once
-          .with('terraform plan -var-file file.tfvars.json', {progress: :dots})
+          .with('terraform plan -var-file file.tfvars.json', progress: :dots)
         expect(subject).to receive(:landscape_format).once.with('TFoutput')
         Rake.application['tf:plan'].invoke
       end
@@ -472,7 +472,7 @@ describe TFWrapper::RakeTasks do
         Rake.application['tf:plan'].clear_prerequisites
         subject.instance_variable_set('@landscape_progress', :lines)
         expect(subject).to receive(:terraform_runner).once
-          .with('terraform plan -var-file file.tfvars.json', {progress: :lines})
+          .with('terraform plan -var-file file.tfvars.json', progress: :lines)
         expect(subject).to receive(:landscape_format).once.with('TFoutput')
         Rake.application['tf:plan'].invoke
       end
@@ -481,7 +481,7 @@ describe TFWrapper::RakeTasks do
         subject.instance_variable_set('@landscape_progress', :stream)
         expect(subject).to receive(:terraform_runner).once
           .with('terraform plan -var-file file.tfvars.json',
-                {progress: :stream})
+                progress: :stream)
         expect(subject).to receive(:landscape_format).once.with('TFoutput')
         Rake.application['tf:plan'].invoke
       end
@@ -495,7 +495,7 @@ describe TFWrapper::RakeTasks do
         Rake.application['tf:plan'].clear_prerequisites
         expect(subject).to receive(:terraform_runner).once
           .with(
-            'terraform plan -var-file file.tfvars.json', {progress: :stream}
+            'terraform plan -var-file file.tfvars.json', progress: :stream
           )
         expect(subject).to_not receive(:landscape_format)
         Rake.application['tf:plan'].invoke
@@ -511,7 +511,7 @@ describe TFWrapper::RakeTasks do
         Rake.application['tf:plan'].clear_prerequisites
         expect(subject).to receive(:terraform_runner).once
           .with(
-            'terraform plan -var-file file.tfvars.json', {progress: :stream}
+            'terraform plan -var-file file.tfvars.json', progress: :stream
           )
         expect(subject).to_not receive(:landscape_format)
         Rake.application['tf:plan'].invoke
@@ -1101,7 +1101,7 @@ describe TFWrapper::RakeTasks do
       )
     end
   end
-  describe '#landscape_format', :if => HAVE_LANDSCAPE do
+  describe '#landscape_format', if: HAVE_LANDSCAPE do
     before(:each) do
       allow(STDERR).to receive(:puts)
       allow(STDOUT).to receive(:puts)
@@ -1136,13 +1136,14 @@ describe TFWrapper::RakeTasks do
           allow(TerraformLandscape::Output)
             .to receive(:new).and_return(dbl_output)
           allow(dbl_printer).to receive(:process_string)
-            .and_raise(RuntimeError, "FooError")
+            .and_raise(RuntimeError, 'FooError')
 
           expect(TerraformLandscape::Output)
             .to receive(:new).once.with(STDOUT)
           expect(TerraformLandscape::Printer)
             .to receive(:new).once.with(dbl_output)
-          expect(dbl_printer).to receive(:process_string).once.with('PlanOutput')
+          expect(dbl_printer)
+            .to receive(:process_string).once.with('PlanOutput')
           expect(STDERR).to receive(:puts).once
             .with(
               'Exception calling terraform_landscape to reformat output: ' \
@@ -1162,13 +1163,14 @@ describe TFWrapper::RakeTasks do
           allow(TerraformLandscape::Output)
             .to receive(:new).and_return(dbl_output)
           allow(dbl_printer).to receive(:process_string)
-            .and_raise(RuntimeError, "FooError")
+            .and_raise(RuntimeError, 'FooError')
 
           expect(TerraformLandscape::Output)
             .to receive(:new).once.with(STDOUT)
           expect(TerraformLandscape::Printer)
             .to receive(:new).once.with(dbl_output)
-          expect(dbl_printer).to receive(:process_string).once.with('PlanOutput')
+          expect(dbl_printer)
+            .to receive(:process_string).once.with('PlanOutput')
           expect(STDERR).to receive(:puts).once
             .with(
               'Exception calling terraform_landscape to reformat output: ' \
@@ -1189,7 +1191,7 @@ describe TFWrapper::RakeTasks do
       allow(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
         .with(any_args).and_return(['MyOutput', 0])
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .once.with('foo', 'tfdir', {stream_type: :stream})
+        .once.with('foo', 'tfdir', stream_type: :stream)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1205,7 +1207,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(2).times.with('foo', 'tfdir', {stream_type: :stream})
+        .exactly(2).times.with('foo', 'tfdir', stream_type: :stream)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1227,7 +1229,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(3).times.with('foo', 'tfdir', {stream_type: :stream})
+        .exactly(3).times.with('foo', 'tfdir', stream_type: :stream)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1252,7 +1254,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(3).times.with('foo', 'tfdir', {stream_type: :dots})
+        .exactly(3).times.with('foo', 'tfdir', stream_type: :dots)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1279,7 +1281,7 @@ describe TFWrapper::RakeTasks do
       end
 
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
-        .exactly(3).times.with('foo', 'tfdir', {stream_type: nil})
+        .exactly(3).times.with('foo', 'tfdir', stream_type: nil)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
@@ -1298,7 +1300,7 @@ describe TFWrapper::RakeTasks do
       allow(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
         .and_return(['', 1])
       expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output).once
-        .with('foo', 'tfdir', {stream_type: :stream})
+        .with('foo', 'tfdir', stream_type: :stream)
       expect(STDERR).to receive(:puts).once
         .with('terraform_runner command: \'foo\' (in tfdir)')
       expect { subject.terraform_runner('foo') }


### PR DESCRIPTION
This adds [terraform-landscape](https://github.com/coinbase/terraform-landscape) support to tfwrapper. terraform-landscape is a terraform wrapper that provides improved formatting of ``terraform plan`` output including pretty diffs of JSON values. See [the project's README](https://github.com/coinbase/terraform-landscape/blob/master/README.md) for some example screenshots.

Note that terraform-landscape doesn't have an official public Ruby API, just a command-line client. We're using the Ruby API. It's not documented, but it's not private either.

For a description of the user-visible changes in this PR, see [the terraform-landscape section of the README in this branch](https://github.com/manheim/tfwrapper/blob/landscape/README.md#terraform-landscape).

All changes are backwards-compatible. This branch includes full unit and acceptance test coverage of the changes, including acceptance test coverage of the output when running without landscape, or with landscape with any of the supported progress options.