### PR TITLE
Fix suppressed output when plan fails and landscape is enabled

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+Version 0.5.1
+
+  - Fix bug where terraform plan errors were suppressed if a plan run with landscape support enabled exited non-zero.
+
 Version 0.5.0
 
   - Add support for using terraform_landscape gem, if present, to reformat plan output; see README for usage.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ with 1.9.3 is simply too high to justify.
 Add to your ``Gemfile``:
 
 ```ruby
-gem 'tfwrapper', '~> 0.5.0'
+gem 'tfwrapper', '~> 0.5.1'
 ```
 
 ### Supported Terraform Versions

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -404,6 +404,8 @@ module TFWrapper
       end
       # end exponential backoff
       unless status.zero?
+        # if we weren't streaming output, send it now
+        STDERR.puts out_err unless stream_type == :stream
         raise StandardError, "Errors have occurred executing: '#{cmd}' " \
           "(exited #{status})"
       end

--- a/lib/tfwrapper/version.rb
+++ b/lib/tfwrapper/version.rb
@@ -4,5 +4,5 @@ module TFWrapper
   # version of the Gem/module; used in the gemspec and in messages.
   # NOTE: When updating this, also update the version in the "Installation"
   # section of README.md
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -922,6 +922,34 @@ describe 'tfwrapper' do
           end
         end
       end
+      context 'when terraform fails' do
+        describe 'failing_tf:plan' do
+          before(:all) do
+            @out_err, @ecode = Open3.capture2e(
+              'timeout -k 60 45 bundle exec rake failing_tf:plan',
+              chdir: @fixturepath
+            )
+            @varpath = File.join(@fixturepath, 'failing_build.tfvars.json')
+          end
+          after(:all) do
+            File.delete(@varpath) if File.file?(@varpath)
+          end
+          it 'does not time out' do
+            expect(@ecode.exitstatus).to_not eq(124)
+            expect(@ecode.exitstatus).to_not eq(137)
+          end
+          it 'exits 1' do
+            expect(@ecode.exitstatus).to eq(1)
+          end
+          it 'returns the terraform output' do
+            expected = clean_tf_plan_output(
+              File.read(File.join(@fixturepath, 'when_terraform_fails.out')),
+              latest_tf_ver, @fixturepath
+            )
+            expect(@out_err.strip).to eq(expected.strip)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/landscapeTest/Rakefile
+++ b/spec/fixtures/landscapeTest/Rakefile
@@ -30,3 +30,9 @@ TFWrapper::RakeTasks.install_tasks(
   namespace_prefix: 'lines',
   landscape_progress: :lines
 )
+
+TFWrapper::RakeTasks.install_tasks(
+  'failingTerraform/',
+  namespace_prefix: 'failing',
+  landscape_progress: :dots
+)

--- a/spec/fixtures/landscapeTest/failingTerraform/main.tf
+++ b/spec/fixtures/landscapeTest/failingTerraform/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = "> 0.9.0"
+  backend "consul" {
+    address = "127.0.0.1:8500"
+    path    = "terraform/landscapeTestFailure"
+  }
+}
+
+provider "consul" {
+  address = "127.0.0.1:8500"
+  version = "~> 1.0"
+}
+
+locals {
+  keys = {
+    foo = "foo2val"
+    bar = "bar2val"
+    baz = "baz2val"
+  }
+}
+
+variable "foo" { default = "bar" }
+
+resource "consul_key_prefix" "landscapeTest" {
+  invalid_param = "whoCares"
+}
+
+output "foo_variable" { value = "${var.foo}" }

--- a/spec/fixtures/landscapeTest/when_terraform_fails.out
+++ b/spec/fixtures/landscapeTest/when_terraform_fails.out
@@ -1,0 +1,67 @@
+Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+terraform_runner command: 'terraform init -input=false' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/failingTerraform)
+Running with: Terraform v0.11.2
+
+Your version of Terraform is out of date! The latest version
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
+
+[0m[1mInitializing the backend...[0m
+[0m[32m
+Successfully configured the backend "consul"! Terraform will automatically
+use this backend unless the backend configuration changes.[0m
+
+[0m[1mInitializing provider plugins...[0m
+- Checking for available provider plugins on https://releases.hashicorp.com...
+- Downloading plugin for provider "consul" (1.0.0)...
+
+[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
+[0m[32m
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.[0m
+terraform_runner command 'terraform init -input=false' finished and exited 0
+Terraform vars written to: /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/failing_build.tfvars.json
+terraform_runner command: 'terraform plan -var-file /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/failing_build.tfvars.json' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/failingTerraform)
+Terraform vars:
+............[31m
+[1m[31mError: [0m[0m[1mconsul_key_prefix.landscapeTest: "path_prefix": required field is not set[0m
+
+[0m[0m[0m
+[31m
+[1m[31mError: [0m[0m[1mconsul_key_prefix.landscapeTest: "subkeys": required field is not set[0m
+
+[0m[0m[0m
+[31m
+[1m[31mError: [0m[0m[1mconsul_key_prefix.landscapeTest: : invalid or unknown key: invalid_param[0m
+
+[0m[0m[0m
+rake aborted!
+StandardError: Errors have occurred executing: 'terraform plan -var-file /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest/failing_build.tfvars.json' (exited 1)
+/home/jantman/manheim/git/github_dot_com/tfwrapper/lib/tfwrapper/raketasks.rb:409:in `terraform_runner'
+/home/jantman/manheim/git/github_dot_com/tfwrapper/lib/tfwrapper/raketasks.rb:202:in `block (2 levels) in install_plan'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
+/home/jantman/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/exe/bundle:22:in `<top (required)>'
+/home/jantman/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `load'
+/home/jantman/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `<main>'
+/home/jantman/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
+/home/jantman/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
+Tasks: TOP => failing_tf:plan
+(See full trace by running task with --trace)

--- a/spec/fixtures/landscapeTest/with_landscape_dots.out
+++ b/spec/fixtures/landscapeTest/with_landscape_dots.out
@@ -1,12 +1,12 @@
 Terraform v0.11.2
 
 Your version of Terraform is out of date! The latest version
-is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
 terraform_runner command: 'terraform init -input=false' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest)
 Running with: Terraform v0.11.2
 
 Your version of Terraform is out of date! The latest version
-is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
 
 [0m[1mInitializing the backend...[0m
 [0m[32m
@@ -43,4 +43,3 @@ Terraform vars:
                     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
-

--- a/spec/fixtures/landscapeTest/with_landscape_lines.out
+++ b/spec/fixtures/landscapeTest/with_landscape_lines.out
@@ -1,12 +1,12 @@
 Terraform v0.11.2
 
 Your version of Terraform is out of date! The latest version
-is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
 terraform_runner command: 'terraform init -input=false' (in /home/jantman/manheim/git/github_dot_com/tfwrapper/spec/fixtures/landscapeTest)
 Running with: Terraform v0.11.2
 
 Your version of Terraform is out of date! The latest version
-is 0.11.5. You can update by downloading from www.terraform.io/downloads.html
+is %%TF_LATEST_VER%%. You can update by downloading from www.terraform.io/downloads.html
 
 [0m[1mInitializing the backend...[0m
 [0m[32m
@@ -68,4 +68,3 @@ terraform_runner command 'terraform plan -var-file /home/jantman/manheim/git/git
                     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
-

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -1306,6 +1306,18 @@ describe TFWrapper::RakeTasks do
       expect { subject.terraform_runner('foo') }
         .to raise_error('Errors have occurred executing: \'foo\' (exited 1)')
     end
+    it 'prints output to STDERR if plan exits non-zero and not :stream' do
+      allow(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
+        .and_return(['myoutput', 1])
+      expect(TFWrapper::Helpers).to receive(:run_cmd_stream_output).once
+        .with('foo', 'tfdir', progress: :dots)
+      expect(STDERR).to receive(:puts).once
+        .with('terraform_runner command: \'foo\' (in tfdir)')
+      expect(STDERR).to receive(:puts).once
+        .with('myoutput')
+      expect { subject.terraform_runner('foo', progress: :dots) }
+        .to raise_error('Errors have occurred executing: \'foo\' (exited 1)')
+    end
     it 'raises an error if the progress option is invalid' do
       allow(TFWrapper::Helpers).to receive(:run_cmd_stream_output)
         .and_return(['', 1])


### PR DESCRIPTION
This fixes a bug where, if terraform_landscape is enabled for improved plan output, error messages are suppressed if the plan command exits non-zero. Now, if the plan exits non-zero, its full output will be printed to STDERR.

This also fixes two acceptance tests that had hard-coded latest terraform versions.