### PR TITLE
show full error output on throttling/401/403

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Metrics/AbcSize:
   Max: 50
 
 Metrics/BlockLength:
-  Max: 1400
+  Max: 1500
 
 Metrics/ClassLength:
   Max: 500

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@ Version 0.6.0
 
   - Include full terraform output when a terraform run fails with output including ``hrottling``, ``status code: 403``, or ``status code: 401``. Previously terraform output was suppressed in these cases, which causes confusion with providers other than "aws" that include these strings in their failure output.
   - In ``Gemfile``, for testing, pin terraform-landscape gem to 0.2.2 for Ruby 2.x compatibility.
+  - Pin ``rb-inotify`` dependency to 0.9.10 to allow build with Ruby < 2.2
   - Switch testing from circleci.com to travis-ci.org
   - Pin terraform_landscape dependency to 0.2.2 for compatibility with ruby < 2.5
   - Acceptance tests:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
-Unreleased Changes
+Version 0.6.0
 
+  - Include full terraform output when a terraform run fails with output including ``hrottling``, ``status code: 403``, or ``status code: 401``. Previously terraform output was suppressed in these cases, which causes confusion with providers other than "aws" that include these strings in their failure output.
+  - In ``Gemfile``, for testing, pin terraform-landscape gem to 0.2.2 for Ruby 2.x compatibility.
   - Switch testing from circleci.com to travis-ci.org
   - Pin terraform_landscape dependency to 0.2.2 for compatibility with ruby < 2.5
   - Acceptance tests:

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -391,15 +391,15 @@ module TFWrapper
           cmd, @tf_dir, progress: stream_type
         )
         if status != 0 && out_err.include?('hrottling')
-          raise StandardError, 'Terraform hit AWS API rate limiting'
+          raise StandardError, "#{out_err}\nTerraform hit AWS API rate limiting"
         end
         if status != 0 && out_err.include?('status code: 403')
-          raise StandardError, 'Terraform command got 403 error - access ' \
-            'denied or credentials not propagated'
+          raise StandardError, "#{out_err}\nTerraform command got 403 error " \
+            '- access denied or credentials not propagated'
         end
         if status != 0 && out_err.include?('status code: 401')
-          raise StandardError, 'Terraform command got 401 error - access ' \
-            'denied or credentials not propagated'
+          raise StandardError, "#{out_err}\nTerraform command got 401 error " \
+            '- access denied or credentials not propagated'
         end
       end
       # end exponential backoff

--- a/lib/tfwrapper/version.rb
+++ b/lib/tfwrapper/version.rb
@@ -4,5 +4,5 @@ module TFWrapper
   # version of the Gem/module; used in the gemspec and in messages.
   # NOTE: When updating this, also update the version in the "Installation"
   # section of README.md
-  VERSION = '0.5.1'
+  VERSION = '0.6.0'
 end

--- a/spec/unit/raketasks_spec.rb
+++ b/spec/unit/raketasks_spec.rb
@@ -1233,10 +1233,12 @@ describe TFWrapper::RakeTasks do
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
-        .with(/terraform_runner\sfailed\swith\sTerraform\shit\sAWS\sAPI\srate\s
+        .with(/terraform_runner\sfailed\swith\sfoo\sThrottling\sbar\s+
+          Terraform\shit\sAWS\sAPI\srate\s
           limiting;\sretry\sattempt\s1;\s.+\sseconds\shave\spassed\./x)
       expect(STDERR).to receive(:puts).once
-        .with(/terraform_runner\sfailed\swith\sTerraform\shit\sAWS\sAPI\srate\s
+        .with(/terraform_runner\sfailed\swith\sfoo\sThrottling\sbar\s+
+          Terraform\shit\sAWS\sAPI\srate\s
           limiting;\sretry\sattempt\s2;\s.+\sseconds\shave\spassed\./x)
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command 'foo' finished and exited 0")
@@ -1258,11 +1260,13 @@ describe TFWrapper::RakeTasks do
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
-        .with(/terraform_runner\sfailed\swith\sTerraform\scommand\sgot\s403\s
+        .with(/terraform_runner\sfailed\swith\sfoo\sstatus\scode:\s403\sbar\s+
+          Terraform\scommand\sgot\s403\s
         error\s-\saccess\sdenied\sor\scredentials\snot\spropagated;\sretry\s
         attempt\s1;\s.+\sseconds\shave\spassed\./x)
       expect(STDERR).to receive(:puts).once
-        .with(/terraform_runner\sfailed\swith\sTerraform\scommand\sgot\s403\s
+        .with(/terraform_runner\sfailed\swith\sfoo\sstatus\scode:\s403\sbar\s+
+          Terraform\scommand\sgot\s403\s
         error\s-\saccess\sdenied\sor\scredentials\snot\spropagated;\sretry\s
         attempt\s2;\s.+\sseconds\shave\spassed\./x)
       expect(STDERR).to receive(:puts).once
@@ -1285,11 +1289,13 @@ describe TFWrapper::RakeTasks do
       expect(STDERR).to receive(:puts).once
         .with("terraform_runner command: 'foo' (in tfdir)")
       expect(STDERR).to receive(:puts).once
-        .with(/terraform_runner\sfailed\swith\sTerraform\scommand\sgot\s401\s
+        .with(/terraform_runner\sfailed\swith\sfoo\sstatus\scode:\s401\sbar\s+
+        Terraform\scommand\sgot\s401\s
         error\s-\saccess\sdenied\sor\scredentials\snot\spropagated;\sretry\s
         attempt\s1;\s.+\sseconds\shave\spassed\./x)
       expect(STDERR).to receive(:puts).once
-        .with(/terraform_runner\sfailed\swith\sTerraform\scommand\sgot\s401\s
+        .with(/terraform_runner\sfailed\swith\sfoo\sstatus\scode:\s401\sbar\s+
+        Terraform\scommand\sgot\s401\s
         error\s-\saccess\sdenied\sor\scredentials\snot\spropagated;\sretry\s
         attempt\s2;\s.+\sseconds\shave\spassed\./x)
       expect(STDERR).to receive(:puts).once

--- a/tfwrapper.gemspec
+++ b/tfwrapper.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   # awful, but these are to allow use with ruby 2.1.x
   gem.add_development_dependency 'ruby_dep', '1.3.1'
   gem.add_development_dependency 'listen', '3.0.7'
+  gem.add_development_dependency 'rb-inotify', '0.9.10'
 
   # guard-yard uses Pry which needs readline. If we're in RVM, we'll need this:
   gem.add_development_dependency 'rb-readline', '~> 0.5'


### PR DESCRIPTION
We're currently seeing some strange failures on one build using this gem, like:

```
terraform_runner failed with Terraform command got 403 error - access denied or credentials not propagated; retry attempt 1; 6.496798736 seconds have passed.
terraform_runner failed with Terraform command got 403 error - access denied or credentials not propagated; retry attempt 2; 11.317637107 seconds have passed.
terraform_runner failed with Terraform command got 403 error - access denied or credentials not propagated; retry attempt 3; 15.0205558 seconds have passed.
terraform_runner failed with Terraform command got 403 error - access denied or credentials not propagated; retry attempt 4; 23.478605264 seconds have passed.
```

We're pretty sure that this has nothing to do with AWS throttling or credential propagation, and is actually coming from a different provider that's outputting ``status code: 403`` in its error message.

tfwrapper shouldn't be swallowing the error output for this, as it's currently assuming that _any_ failure including ``throttling``, ``status code: 401``, or ``status code: 403`` is an AWS throttling or credential propagation issue.

This PR changes it to output the full terraform run output in the error message.