### PR TITLE
0.6.1 - Add ``allowed_empty_vars`` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,13 @@ matrix:
     name: "ruby-2.3 acceptance TF 0.11.2"
   - rvm: 2.3
     install: bundle install
-    script: bundle exec rake spec:acceptance TF_VERSION=latest
-    name: "ruby-2.3 acceptance TF latest"
+    script: bundle exec rake spec:acceptance TF_VERSION=0.11.14
+    name: "ruby-2.3 acceptance TF 0.11.14"
   - rvm: 2.4
     install: bundle install
     script: bundle exec rake spec:unit
     name: "ruby-2.4 unit"
   - rvm: 2.4
     install: bundle install
-    script: bundle exec rake spec:acceptance TF_VERSION=latest
-    name: "ruby-2.4 acceptance TF latest"
+    script: bundle exec rake spec:acceptance TF_VERSION=0.11.14
+    name: "ruby-2.4 acceptance TF 0.11.14"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+Version 0.6.1
+
+  - Add ``allowed_empty_vars`` option.
+  - Only support terraform up to 0.11.14.
+
 Version 0.6.0
 
   - Include full terraform output when a terraform run fails with output including ``hrottling``, ``status code: 403``, or ``status code: 401``. Previously terraform output was suppressed in these cases, which causes confusion with providers other than "aws" that include these strings in their failure output.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Build of master branch: [![TravisCI](https://api.travis-ci.org/manheim/tfwrapper
 
 Documentation: [http://www.rubydoc.info/gems/tfwrapper/](http://www.rubydoc.info/gems/tfwrapper/)
 
-tfwrapper provides Rake tasks for working with [Hashicorp Terraform](https://www.terraform.io/) 0.9+, ensuring proper initialization and passing in variables from the environment or Ruby, as well as optionally pushing some information to Consul. tfwrapper also attempts to detect and retry
+tfwrapper provides Rake tasks for working with [Hashicorp Terraform](https://www.terraform.io/) 0.9 through 0.11, ensuring proper initialization and passing in variables from the environment or Ruby, as well as optionally pushing some information to Consul. tfwrapper also attempts to detect and retry
 failed runs due to AWS throttling or access denied errors.
 
 ## Overview
@@ -49,7 +49,7 @@ gem 'tfwrapper', '~> 0.6.1'
 
 ### Supported Terraform Versions
 
-tfwrapper only supports terraform 0.9+. It is tested against multiple versions from 0.9.2 to 0.10.2 and the current release.
+tfwrapper only supports terraform 0.9-0.11. It is tested against multiple versions from 0.9.2 to 0.11.14.
 
 ### Terraform Landscape
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ with 1.9.3 is simply too high to justify.
 Add to your ``Gemfile``:
 
 ```ruby
-gem 'tfwrapper', '~> 0.5.1'
+gem 'tfwrapper', '~> 0.6.1'
 ```
 
 ### Supported Terraform Versions
@@ -146,6 +146,10 @@ TFWrapper::RakeTasks.install_tasks(
   }
 )
 ```
+
+These variables are tested to be set in the environment with a non-empty value, and will raise an error if any are
+missing or empty. If some should be allowed to be missing or empty empty, pass a ``allowed_empty_vars`` list with
+their environment variable names.
 
 ### Ruby Variables to Terraform Variables
 

--- a/lib/tfwrapper/helpers.rb
+++ b/lib/tfwrapper/helpers.rb
@@ -78,9 +78,12 @@ module TFWrapper
     # non-empty. Raise StandardError if any aren't.
     #
     # @param required [Array] list of required environment variables
-    def self.check_env_vars(required)
+    # @param allowed_missing [Array] list of environment variables to allow to
+    #  be empty or missing.
+    def self.check_env_vars(required, allowed_missing)
       missing = []
       required.each do |name|
+        next if allowed_missing.include?(name)
         if !ENV.include?(name)
           puts "ERROR: Environment variable '#{name}' must be set."
           missing << name

--- a/lib/tfwrapper/raketasks.rb
+++ b/lib/tfwrapper/raketasks.rb
@@ -55,6 +55,8 @@ module TFWrapper
     #   configurations in the same Rakefile.
     # @option opts [Hash] :tf_vars_from_env hash of Terraform variables to the
     #   (required) environment variables to populate their values from
+    # @option opts [Hash] :allowed_empty_vars array of environment variable
+    #   names (specified in :tf_vars_from_env) to allow to be empty or missing.
     # @option opts [Hash] :tf_extra_vars hash of Terraform variables to their
     #   values; overrides any same-named keys in ``tf_vars_from_env``
     # @option opts [String] :consul_url URL to access Consul at, for the
@@ -96,6 +98,7 @@ module TFWrapper
       @ns_prefix = opts.fetch(:namespace_prefix, nil)
       @consul_env_vars_prefix = opts.fetch(:consul_env_vars_prefix, nil)
       @tf_vars_from_env = opts.fetch(:tf_vars_from_env, {})
+      @allowed_empty_vars = opts.fetch(:allowed_empty_vars, [])
       @tf_extra_vars = opts.fetch(:tf_extra_vars, {})
       @backend_config = opts.fetch(:backend_config, {})
       @consul_url = opts.fetch(:consul_url, nil)
@@ -162,7 +165,9 @@ module TFWrapper
         desc 'Run terraform init with appropriate arguments'
         task :init do |t|
           @before_proc.call(t.name, @tf_dir) unless @before_proc.nil?
-          TFWrapper::Helpers.check_env_vars(@tf_vars_from_env.values)
+          TFWrapper::Helpers.check_env_vars(
+            @tf_vars_from_env.values, @allowed_empty_vars
+          )
           @tf_version = check_tf_version
           cmd = [
             'terraform',

--- a/lib/tfwrapper/version.rb
+++ b/lib/tfwrapper/version.rb
@@ -4,5 +4,5 @@ module TFWrapper
   # version of the Gem/module; used in the gemspec and in messages.
   # NOTE: When updating this, also update the version in the "Installation"
   # section of README.md
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
Right now, tfwrapper throws an error if any of the configured environment variables are missing or empty. This PR adds an ``allowed_empty_vars`` option, to allow specifying a list of environment variables that are allowed to be empty.

This also limits testing to tf 0.11.14, not 0.12, as this doesn't necessarily support 0.12 and the acceptance tests definitely don't.

## Testing done

spec and rubocop  tests succeed locally