### PR TITLE
update README for migration to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tfwrapper
 
-Build of master branch: [![TravisCI](https://api.travis-ci.org/manheim/tfwrapper.svg?branch=master)](https://travis-ci.org/manheim/tfwrapper)
+Build of master branch: [![TravisCI](https://api.travis-ci.com/manheim/tfwrapper.svg?branch=master)](https://travis-ci.com/github/manheim/tfwrapper)
 
 Documentation: [http://www.rubydoc.info/gems/tfwrapper/](http://www.rubydoc.info/gems/tfwrapper/)
 


### PR DESCRIPTION
This repository has been migrated from travis-ci.org to travis-ci.com. This PR just updates the README accordingly.